### PR TITLE
Some dev dependencies are missing in the gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,9 @@ GEM
     multi_json (1.0.3)
     polyglot (0.3.1)
     rack (1.3.0)
+    rake (0.8.7)
     rb-fsevent (0.4.0)
+    rdoc (3.5.3)
     sass (3.1.1)
     sinatra (1.2.6)
       rack (~> 1.1)
@@ -80,5 +82,7 @@ DEPENDENCIES
   guard-compass
   guard-ego
   mailcatcher!
+  rake
   rb-fsevent
+  rdoc
   sass (~> 3.1)

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -38,6 +38,8 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra",       "~> 1.2"
   s.add_dependency "haml",          "~> 3.1"
 
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rdoc"
   s.add_development_dependency "sass", "~> 3.1"
   s.add_development_dependency "compass", "~> 0.11.1"
   s.add_development_dependency "coffee-script", "~> 2.2"


### PR DESCRIPTION
Namely rake and rdoc. The changes in this pull request add them. This should make it easier for others to start hacking on mailcatcher.

Thanks for taking a look.

Gregor
