### PR TITLE
Some click handlers do not prevent the default action

### DIFF
--- a/public/javascripts/application.coffee
+++ b/public/javascripts/application.coffee
@@ -25,6 +25,7 @@ class MailCatcher
               height: e.clientY - $('#messages').offset().top
 
     $('nav.app .clear a').live 'click', (e) =>
+      e.preventDefault()
       if confirm "You will lose all your received messages.\n\nAre you sure you want to clear all messages?"
         $.ajax
           url: '/messages'
@@ -37,6 +38,7 @@ class MailCatcher
             alert 'Error while quitting.'
 
     $('nav.app .quit a').live 'click', (e) =>
+      e.preventDefault()
       if confirm "You will lose all your received messages.\n\nAre you sure you want to quit?"
         $.ajax
           type: 'DELETE'

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -34,6 +34,7 @@
         }
       });
       $('nav.app .clear a').live('click', __bind(function(e) {
+        e.preventDefault();
         if (confirm("You will lose all your received messages.\n\nAre you sure you want to clear all messages?")) {
           return $.ajax({
             url: '/messages',
@@ -50,6 +51,7 @@
         }
       }, this));
       $('nav.app .quit a').live('click', __bind(function(e) {
+        e.preventDefault();
         if (confirm("You will lose all your received messages.\n\nAre you sure you want to quit?")) {
           return $.ajax({
             type: 'DELETE',


### PR DESCRIPTION
This results in ugly '/#' in the location bar. This might not be live threatening but I think it's ugly. This pull requests adds `e.preventDefault()` at the right places.

Thanks for taking a look.

Gregor
