### PR TITLE
Using old-style Hash literal to work with 1.8.7

### DIFF
--- a/lib/mail_catcher/web.rb
+++ b/lib/mail_catcher/web.rb
@@ -126,7 +126,7 @@ class MailCatcher::Web < Sinatra::Base
     if part = MailCatcher::Mail.message_part_html(id)
       # TODO: Server-side cache? Make the browser cache based on message create time? Hmm.
       uri = URI.parse("http://api.getfractal.com/api/v2/validate#{"/format/#{params[:format]}" if params[:format].present?}")
-      response = Net::HTTP.post_form(uri, api_key: "5c463877265251386f516f7428", html: part["body"])
+      response = Net::HTTP.post_form(uri, :api_key => "5c463877265251386f516f7428", :html => part["body"])
       content_type ".#{params[:format]}" if params[:format].present?
       body response.body
     else


### PR DESCRIPTION
In 8871108, you introduced a Hash literal using the new 1.9-only Hash syntax. This makes mailcatcher 0.5.2 throw SyntaxErrors on older ruby version - most notably 1.8.7.

The attached changes make mailcatcher work on 1.8.7 again.

Thanks,

Gregor
