### PR TITLE
Fixed daemonizing in development

### DIFF
--- a/lib/mail_catcher/web.rb
+++ b/lib/mail_catcher/web.rb
@@ -10,7 +10,7 @@ class Sinatra::Request
 end
 
 class MailCatcher::Web < Sinatra::Base
-  set :root, Pathname.new(__FILE__).dirname.parent.parent
+  set :root, Pathname.new(__FILE__).expand_path.dirname.parent.parent
   set :haml, :format => :html5
 
   get '/' do


### PR DESCRIPTION
Running in developement like `ruby -Ilib -rrubygems bin/mailcatcher` was broken as root path given for sinatra was relative and was broken when daemonized process got its current directory changed to `/`.
