### PR TITLE
Fix clearing all messages

### DIFF
--- a/public/javascripts/application.coffee
+++ b/public/javascripts/application.coffee
@@ -44,7 +44,7 @@ class MailCatcher
           success: =>
             @unselectMessage()
           error: ->
-            alert 'Error while quitting.'
+            alert 'Error while clearing all messages.'
 
     $('nav.app .quit a').live 'click', (e) =>
       e.preventDefault()

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -75,7 +75,7 @@
               return _this.unselectMessage();
             },
             error: function() {
-              return alert('Error while quitting.');
+              return alert('Error while clearing all messages.');
             }
           });
         }


### PR DESCRIPTION
Attempting to clear all messages results in a JS error preventing the UI from updating itself.

Also the error message displayed when the AJAX call fails is incorrect.
