### PR TITLE
HTML Links can break in quoted printable email output

### DIFF
--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -34,10 +34,7 @@ class MailCatcher::Smtp < EventMachine::Protocols::SmtpServer
 
   def receive_data_chunk(lines)
     current_message[:source] ||= ""
-    lines.each do |line|
-      # RFC821 4.5.2 says leading periods should be stripped from the body data.
-      current_message[:source] << line.sub(/\A\./, "") << "\n"
-    end
+    current_message[:source] << lines.join("\n")
     true
   end
 


### PR DESCRIPTION
When sending a HTML email that uses quoted printable transfer encoding (ActionMailer default), links can break when the line is split before a period in the link due to leading periods being removed twice, the quoted printable encoding adds an extra period as specified in the RFC, giving 2 to start with, these are then both removed, 

once by event machine
https://github.com/eventmachine/eventmachine/blob/master/lib/em/protocols/smtpserver.rb#L547

and then a second time by mailcatcher.
https://github.com/sj26/mailcatcher/blob/master/lib/mail_catcher/smtp.rb#L39

A simple script to repllicate the issue can be found here,
https://gist.github.com/JWells/5519294
