### PR TITLE
ignore common sendmail options

### DIFF
--- a/bin/catchmail
+++ b/bin/catchmail
@@ -32,6 +32,13 @@ OptionParser.new do |parser|
   parser.on('-f FROM', 'Set the sending address') do |from|
     options[:from] = from
   end
+  
+  parser.on('-oi', 'Ignored option -oi') do |ignored|
+  end
+  parser.on('-t', 'Ignored option -t') do |ignored|
+  end
+  parser.on('-q', 'Ignored option -q') do |ignored|
+  end
 
   parser.on('-h', '--help', 'Display this help information') do
     puts parser


### PR DESCRIPTION
related to https://github.com/sj26/mailcatcher/issues/103 and expanded to include other common options that are commonly used (e.g. phpmailer uses -oi and -t by default)
