### PR TITLE
Syncing output when running in foreground.

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -142,6 +142,11 @@ module MailCatcher extend self
     # Stash them away for later
     @@options = options
 
+    # If we're running in the foreground sync the output.
+    unless options[:daemon]
+      $stdout.sync = $stderr.sync = true
+    end
+
     puts "Starting MailCatcher"
 
     Thin::Logging.silent = true


### PR DESCRIPTION
When running mailcatcher in the foreground with [foreman](https://github.com/ddollar/foreman), it doesn't propely syncs the output.

I ran into this issue and decided to fix it for everyone.

fixes #79
