### PR TITLE
Extend activesupport dependency to include 4.x

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.8.7'
 
-  s.add_dependency "activesupport", ">= 3.0.0", "< 4.1"
+  s.add_dependency "activesupport", ">= 3.0.0", "< 5"
   s.add_dependency "eventmachine", "~> 1.0.0"
   s.add_dependency "haml", ">= 3.1", "< 4.1"
   s.add_dependency "mail", "~> 2.3"


### PR DESCRIPTION
After my recent comment on #98, I noticed the version constraint on `activesupport` exludes 4.1.x. I also noticed that the README discourages from adding MailCatcher to a project's Gemfile, so I understand that that's not supported and will act accordingly. ;)

I would still suggest loosening the version constraint. Seeing as activesupport uses semantic versioning, they should not be introducing backwards-incompatible changes until version 5.x. Thus, if some 4.x version breaks MailCatcher, that's most likely an error on their part and not something that needs to be prevented with strict constraints.

The same can be said of the `haml` constraint, as they use semantic versioning [from version 4.0.0 onwards](http://haml.info/docs/yardoc/file.CHANGELOG.html#400), but I'm keeping that out of this PR.
