### PR TITLE
Add current directory to load path for Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "fileutils"
 require "rubygems"
 
+$:.unshift File.expand_path("./lib")
 require "mail_catcher/version"
 
 # XXX: Would prefer to use Rake::SprocketsTask but can't populate

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -2,7 +2,7 @@ require "open3"
 require "optparse"
 require "rbconfig"
 
-require "active_support"
+require "active_support/all"
 require "eventmachine"
 require "thin"
 


### PR DESCRIPTION
Before it could not find that file on ruby 2.1

Also add active_support core extensions

Before:
```ruby
MailCatcher.run!(daemon: false)
```
cause error
```
mail_catcher.rb:128:in `run!': undefined method `reverse_merge' for {:daemon=>false}:Hash (NoMethodError)
```