### PR TITLE
Ensure messages are shown in the order they were recieved

### DIFF
--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -69,7 +69,7 @@ module MailCatcher::Mail extend self
   end
 
   def messages
-    @messages_query ||= db.prepare "SELECT id, sender, recipients, subject, size, created_at FROM message ORDER BY created_at ASC"
+    @messages_query ||= db.prepare "SELECT id, sender, recipients, subject, size, created_at FROM message ORDER BY created_at, id ASC"
     @messages_query.execute.map do |row|
       Hash[row.fields.zip(row)].tap do |message|
         message["recipients"] &&= ActiveSupport::JSON.decode message["recipients"]


### PR DESCRIPTION
If two messages were received within the same second, they may be sorted by the order they were received. Using `id` as a tie breaker should give a more consistent result.

I noticed this issue when writing tests for my Codeception testing framework Mailcatcher module: https://github.com/captbaritone/codeception-mailcatcher-module/issues/13 

**Note:** I have not tested this change, but I think it should be correct.