### PR TITLE
requiring eventmachine to be less than 1.0.4 as 1.0.4 causes timeouts

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
 
   s.add_dependency "activesupport", "~> 3.0"
-  s.add_dependency "eventmachine", "~> 1.0.0"
+  s.add_dependency "eventmachine", "< 1.0.4"
   s.add_dependency "haml", ">= 3.1", "< 5"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "sinatra", "~> 1.2"


### PR DESCRIPTION
This is a temporary fix that forces mailcatcher to use eventmachine -v 1.0.3 or less