### PR TITLE
add default_url_options to rails section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Under RVM your mailcatcher command may only be available under the ruby you inst
 
 To set up your rails app, I recommend adding this to your `environments/development.rb`:
 
+    config.action_mailer.default_url_options = {:host => 'localhost:3000'}
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
 


### PR DESCRIPTION
Without it i have
```ruby
ActionView::Template::Error: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true
```