### PR TITLE
Remove 'Quit' button if app is not quittable

### DIFF
--- a/bin/catchmail
+++ b/bin/catchmail
@@ -41,7 +41,7 @@ OptionParser.new do |parser|
   end
 
   parser.on('-x', '--no-exit', 'Can\'t exit from the application') do
-    options[:no_exit] = true
+    options[:quit] = false
   end
 
   parser.on('-h', '--help', 'Display this help information') do

--- a/views/index.erb
+++ b/views/index.erb
@@ -13,7 +13,7 @@
       <ul>
         <li class="search"><input type="search" name="search" placeholder="Search messages..." incremental="true" /></li>
         <li class="clear"><a href="#" title="Clear all messages">Clear</a></li>
-        <% unless MailCatcher.options[:no_exit] %>
+        <% if MailCatcher.quittable? %>
           <li class="quit"><a href="#" title="Quit MailCatcher">Quit</a></li>
         <% end %>
       </ul>


### PR DESCRIPTION
When '--no-quit' option is used, 'Quit' button will show an error when user attempts to quit. This patch fixes that by removing the button.

Thanks for the great app!

Vlada