### PR TITLE
Bugfix: fix non-working which method

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -24,7 +24,7 @@ require "mail_catcher/version"
 
 module MailCatcher extend self
   def which(command)
-    not windows? and Open3.popen3 'which', 'command' do |stdin, stdout, stderr|
+    not windows? and Open3.popen3 'which', command do |stdin, stdout, stderr|
       return stdout.read.chomp.presence
     end
   end

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -112,7 +112,7 @@ module MailCatcher extend self
         if mac?
           parser.on("--[no-]growl") do |growl|
             puts "Growl is no longer supported"
-            exit -2
+            exit(-2)
           end
         end
 
@@ -211,7 +211,7 @@ protected
     rescue RuntimeError
       if $!.to_s =~ /\bno acceptor\b/
         puts "~~> ERROR: Something's using port #{port}. Are you already running MailCatcher?"
-        exit -1
+        exit(-1)
       else
         raise
       end

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -24,8 +24,15 @@ require "mail_catcher/version"
 
 module MailCatcher extend self
   def which(command)
-    not windows? and Open3.popen3 'which', command do |stdin, stdout, stderr|
-      return stdout.read.chomp.presence
+    return if windows?
+
+    begin
+      Open3.popen3 'which', command do |stdin, stdout, stderr|
+        return stdout.read.chomp.presence
+      end
+    rescue Errno::ENOENT
+      warn "The `which` builtin shell command was not found. Are you running a minimal shell?"
+      exit(-3)
     end
   end
 

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -111,7 +111,7 @@ module MailCatcher extend self
 
         if mac?
           parser.on("--[no-]growl") do |growl|
-            puts "Growl is no longer supported"
+            warn "Growl is no longer supported"
             exit(-2)
           end
         end
@@ -210,7 +210,7 @@ protected
     # XXX: EventMachine only spits out RuntimeError with a string description
     rescue RuntimeError
       if $!.to_s =~ /\bno acceptor\b/
-        puts "~~> ERROR: Something's using port #{port}. Are you already running MailCatcher?"
+        warn "~~> ERROR: Something's using port #{port}. Are you already running MailCatcher?"
         exit(-1)
       else
         raise


### PR DESCRIPTION
Hi there,

A colleague uses [NixOS](nixos.org) and it's an ultra-minimalist declarative functional OS... I think :)

Anyway - we were pulling MailCatcher in as a dependency into the project, and it broke with a weird popen3 exception somewhere in the ruby stdlib.

Anyway - we tracked it down to the nixos setup, and also at the same time, I noticed a bug whereby the argument to #which() was not being used and a hardcoded string was sent instead.

I've fixed the command arg thing, and also handled the exception Errno::ENOENT exception within mailcatcher with a more useful error message.

Hope you like :) and thanks for an amazing tool. It's a daily part of our lives.
