### PR TITLE
Fix #210 by upgrading eventmachine

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
 
   s.add_dependency "activesupport", ">= 4.0.0", "< 5"
-  s.add_dependency "eventmachine", "~> 1.0.0", "<= 1.0.5"
+  s.add_dependency "eventmachine", "~> 1.0.0", "<= 1.0.8"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"


### PR DESCRIPTION
..  to a version with https://github.com/eventmachine/eventmachine/pull/586 applied

Completely untested on my part, but it looks like this is somewhat covered by testing in the 2.1 memory leak branch.