### PR TITLE
Fix delete message queries conflicting

### DIFF
--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -144,11 +144,11 @@ module MailCatcher::Mail extend self
   end
 
   def delete!
-    @delete_messages_query ||= db.prepare "DELETE FROM message"
-    @delete_message_parts_query ||= db.prepare "DELETE FROM message_part"
+    @delete_all_messages_query ||= db.prepare "DELETE FROM message"
+    @delete_all_message_parts_query ||= db.prepare "DELETE FROM message_part"
 
-    @delete_messages_query.execute and
-    @delete_message_parts_query.execute
+    @delete_all_messages_query.execute and
+    @delete_all_message_parts_query.execute
   end
 
   def delete_message!(message_id)


### PR DESCRIPTION
Once the delete all messages query is assigned, the user cannot delete single messages, and vice versa (until mailcatcher is restarted).