### PR TITLE
Make buildable on x86-mingw32

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     mailcatcher (0.6.2)
       activesupport (>= 4.0.0, < 5)
-      eventmachine (= 1.0.8)
+      eventmachine (= 1.0.9.1)
       mail (~> 2.3)
       sinatra (~> 1.2)
       skinny (~> 0.2.3)
@@ -39,9 +39,10 @@ GEM
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     daemons (1.2.3)
-    eventmachine (1.0.8)
+    eventmachine (1.0.9.1)
     execjs (2.2.2)
     ffi (1.9.6)
+    ffi (1.9.6-x86-mingw32)
     hike (1.2.3)
     i18n (0.7.0)
     json (1.8.2)
@@ -84,6 +85,7 @@ GEM
       sprockets (~> 2.0)
       tilt (~> 1.1)
     sqlite3 (1.3.11)
+    sqlite3 (1.3.11-x86-mingw32)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -99,6 +101,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   coffee-script

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_dependency "activesupport", ">= 4.0.0", "< 5"
-  s.add_dependency "eventmachine", "1.0.8"
+  s.add_dependency "eventmachine", "1.0.9.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"


### PR DESCRIPTION
I feel like a jerk for even needing this, but unfortunately I'm on Windows. This updated dependency on EM in the Gemspec builds fine on Windows, although the one you have now does not.