### PR TITLE
Fix activesupport version

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "activesupport", ">= 4.0.0", "< 5"
+  s.add_dependency "activesupport", ">= 4.0.0", "<= 4.9.9"
   s.add_dependency "eventmachine", "1.0.9.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "sinatra", "~> 1.2"


### PR DESCRIPTION
Ruby does not seem to detect `5.0.0.beta1` of activesupport as being greater than `5` so when gem installing on a fresh version of Debian Jessie (8.2 - stable) it fails with the error

https://github.com/alasdairdc/mailcatcher.git    Fetching activesupport-5.0.0.beta1.gem (100%)
    Error installing mailcatcher:
        activesupport requires Ruby version >= 2.2.2.

as Debian stable version of Ruby is currently `2.1.5+deb8u1`
