### PR TITLE
Constrain mime-types gem version for Ruby v1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'mime-types', '~> 2.99' if RUBY_VERSION < '2.0'
 # gem "eventmachine", path: "#{ENV["HOME"]}/Projects/eventmachine"
 
 #group :development do


### PR DESCRIPTION
💁  The `mime-types`  gem removed support for MRI Ruby versions prior to 2.0 in version 3. This change adds a conditional constraint around the `RUBY_VERSION` constant in the Gemfile, which allows the required Ruby version constraint in the gemspec to be maintained as well as enabling gem installation under MRI Ruby v1.9.3.