### PR TITLE
Allow any Rack version between 1.5 and 3.0

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "eventmachine", "1.0.9.1"
   s.add_dependency "mail", "~> 2.3"
-  s.add_dependency "rack", "~> 1.5"
+  s.add_dependency "rack", ">= 1.5", "<= 3.0"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
   s.add_dependency "thin", "~> 1.5.0"


### PR DESCRIPTION
Rails 5.0.0 requires actionpack 5.0.0, which requires Rack ~> 2.0: https://rubygems.org/gems/actionpack.

This commit relaxes the Rack dependency of Mailcatcher so that older/newer versions of Rails can both work.
