### PR TITLE
Fix undefined method reverse_merge on Mailcatcher#run!

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -153,7 +153,7 @@ module MailCatcher extend self
 
   def run! options=nil
     # If we are passed options, fill in the blanks
-    options &&= options.reverse_merge @@defaults
+    options &&= @@defaults.merge options
     # Otherwise, parse them from ARGV
     options ||= parse!
 


### PR DESCRIPTION
### Context
Since we don't have ActiveSupport anymore(removed on 0021a2909c138732ac1f1393ed6e9d0f385778c1) we should stop using 
[Hash#reverse_merge](http://apidock.com/rails/Hash/reverse_merge) method.

This PR aims to fix this.

### How to reproduce:

On irb run the following:

```ruby
require 'mailcatcher'

Mailcatcher.run!(daemon: false)
# => NoMethodError: undefined method `reverse_merge' for {:daemon=>false}:Hash
```

### After change:
```ruby
require 'mailcatcher'

Mailcatcher.run!(daemon: false)
# => Starting MailCatcher
# ==> smtp://127.0.0.1:1025
# ==> http://127.0.0.1:1080
```


### Off Topic Comments
@sj26 thanks for maintaining this project! 💐 