### PR TITLE
Ruby 1.9 Compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-# mime-types 3+, required by mail, requires ruby 2.0+
-gem "mime-types", "< 3" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2")
-
 #group :development do
 #  gem "pry"
 #end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "eventmachine", "1.0.9.1"
   s.add_dependency "mail", "~> 2.3"
+  s.add_dependency "mime-types", "< 3" # for Ruby 1.9 compatibility
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"


### PR DESCRIPTION
I went to do some work on Ubuntu Trusty, and found that mailcatcher won't easily install with the system ruby.

After reviewing #277 and #286, I realized there was an easy fix. Just put the hack from #286 into the gemspec, instead of the Gemfile.

`mail` is the gem that depends on `'mime-types`. 

Through [2.5](https://github.com/mikel/mail/blob/2-5-stable/mail.gemspec), mail depends on:
`'mime-types', "~> 1.16"`

Since mail [2.6](https://github.com/mikel/mail/blob/2-6-stable/mail.gemspec) it depends on:
`'mime-types', [">= 1.16", "< 4"]`

This means that if you don't want to depend on `mime-types` directly, we can also resolve this by depending on a more specific `mail` release. E.g.:

```ruby
  s.add_dependency "mail", "~> 2.5.2"
```