### PR TITLE
Reject 8bit messages

### DIFF
--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -43,6 +43,9 @@ class MailCatcher::Smtp < EventMachine::Protocols::SmtpServer
   end
 
   def receive_message
+    if /\A[0x00-0x7F]*\z/ !~ current_message[:source]
+      raise "invalid message"
+    end
     MailCatcher::Mail.add_message current_message
     puts "==> SMTP: Received message from '#{current_message[:sender]}' (#{current_message[:source].length} bytes)"
     true


### PR DESCRIPTION
because SMTP server does not respond with 8BITMIME to the EHLO command.