### PR TITLE
Add overlow: auto to #message > header style

### DIFF
--- a/assets/stylesheets/mailcatcher.css.sass
+++ b/assets/stylesheets/mailcatcher.css.sass
@@ -157,6 +157,7 @@ body > header
   box-flex: 1
   > header
     +clearfix
+    overflow: auto;
     .metadata
       +clearfix
       padding: .5em


### PR DESCRIPTION
If there are more than a couple of lines of addressees, the wrapping of
the dd.to element pushes the content below it down behind the message
pane, and the tabs for html/text/source as well as the download button cannot be
accessed (because the Compass reset css defaults to overflow: hidden). 
Adding this style puts a scroll on the message header when needed so that 
the user can get to those elements of the UI.

before:
![before](https://cloud.githubusercontent.com/assets/21490/23774998/7546b64c-04f4-11e7-83fd-0165b4ecd006.png)

after:
![after](https://cloud.githubusercontent.com/assets/21490/23775000/76eb872a-04f4-11e7-9c96-af57bab15731.png)

