### PR TITLE
Select and view the newest email if "autoselect" checkbox is turned on

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -178,6 +178,11 @@ class MailCatcher
   selectedMessage: ->
     $("#messages tr.selected").data "message-id"
 
+  autoselectLatestMessage: ->
+    console.log("autoselectLatestMessage()")
+    console.log($("input[name='autoselect']").attr('checked') == true)
+    $("input[name='autoselect']").attr('checked') == true
+
   searchMessages: (query) ->
     selector = (":icontains('#{token}')" for token in query.split /\s+/).join("")
     $rows = $("#messages tbody tr")
@@ -298,6 +303,8 @@ class MailCatcher
     @websocket = new WebSocket("#{protocol}://#{window.location.host}/messages")
     @websocket.onmessage = (event) =>
       @addMessage $.parseJSON event.data
+      if @autoselectLatestMessage()
+        @loadMessage $("#messages tbody tr[data-message-id]:first").data("message-id")
 
   subscribePoll: ->
     unless @refreshInterval?

--- a/assets/stylesheets/mailcatcher.css.sass
+++ b/assets/stylesheets/mailcatcher.css.sass
@@ -255,3 +255,7 @@ iframe
   -webkit-box-flex: 1
   box-flex: 1
   background: #fff
+
+.autoselect-checkbox
+  padding: 0
+  margin: 0 4px 0 0

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -58,6 +58,14 @@ describe MailCatcher do
     messages_element.find_element(:xpath, ".//table/tbody/tr[1]")
   end
 
+  def message_selected_row_element
+    begin
+      messages_element.find_element(:css, "table tbody tr.selected")
+    rescue Selenium::WebDriver::Error::NoSuchElementError
+      return nil
+    end
+  end
+
   def message_from_element
     message_row_element.find_element(:xpath, ".//td[1]")
   end
@@ -68,6 +76,11 @@ describe MailCatcher do
 
   def message_subject_element
     message_row_element.find_element(:xpath, ".//td[3]")
+  end
+
+  def selected_message_subject_element
+    # if not found, message_selected_row_element returns nil... and it goes wonky from there
+    message_selected_row_element.find_element(:xpath, ".//td[3]")
   end
 
   def message_received_element
@@ -223,5 +236,21 @@ describe MailCatcher do
     deliver_example("quoted_printable_htmlmail")
 
     skip
+  end
+
+  it "selected newest mail when autoselect checkbox is on" do
+    deliver_example("plainmail")
+    message_selected_row_element.must_be_nil
+
+    # turn on the autoselect
+    selenium.find_element(:css, "input[name='autoselect']").click
+
+    # send first email
+    deliver_example("plainmail")
+    selected_message_subject_element.text.must_equal "Plain mail"
+
+    # send another
+    deliver_example("htmlmail")
+    selected_message_subject_element.text.must_equal "Test HTML Mail"
   end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -11,6 +11,7 @@
     <h1><a href="http://mailcatcher.me" target="_blank">MailCatcher</a></h1>
     <nav class="app">
       <ul>
+        <li class="autoselect"><a href="#" title="Select incoming email"><label><input type="checkbox" name="autoselect" class="autoselect-checkbox">Autoselect</label></a></li>
         <li class="search"><input type="search" name="search" placeholder="Search messages..." incremental="true" /></li>
         <li class="clear"><a href="#" title="Clear all messages">Clear</a></li>
         <% if MailCatcher.quittable? %>


### PR DESCRIPTION
Developing responsive HTML email, the workflow will be much faster when the latest email is selected and visible on email viewer. The functionality is controlled by toggling "Autoselect" from menu bar. 

This is how it looks on UI:
<img width="370" alt="screenshot" src="https://cloud.githubusercontent.com/assets/24655/23826868/3fd4c5be-06af-11e7-9d6c-ba842772fa92.png">

Since I'm not sure what are the UI design principles for this project, feel free to rename/restyle the UI component to make it blend in. It's just a label and checkbox. There is just one new ruleset in CSS.