### PR TITLE
Show email size in table and mail detail

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -136,6 +136,20 @@ class MailCatcher
     date &&= @offsetTimeZone(date)
     date &&= date.toString("dddd, d MMM yyyy h:mm:ss tt")
 
+  formatSize: (bytes) ->
+    thresh = 1000
+    units = ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+    if Math.abs(bytes) < thresh
+      return bytes + ' B'
+    u = -1
+    loop
+      bytes /= thresh
+      ++u
+      unless Math.abs(bytes) >= thresh and u < units.length - 1
+        break
+    bytes.toFixed(1) + ' ' + units[u]
+
   messagesCount: ->
     $("#messages tr").length - 1
 
@@ -193,6 +207,7 @@ class MailCatcher
       .append($("<td/>").text((message.recipients || []).join(", ") or "No receipients").toggleClass("blank", !message.recipients.length))
       .append($("<td/>").text(message.subject or "No subject").toggleClass("blank", !message.subject))
       .append($("<td/>").text(@formatDate(message.created_at)))
+      .append($("<td/>").text(@formatSize(message.size)))
       .prependTo($("#messages tbody"))
     @updateMessagesCount()
 
@@ -226,6 +241,11 @@ class MailCatcher
         $("#message .metadata dd.from").text(message.sender)
         $("#message .metadata dd.to").text((message.recipients || []).join(", "))
         $("#message .metadata dd.subject").text(message.subject)
+        $("#message .metadata dd.size").html(
+          $('<span />')
+            .attr('title', message.size+' bytes')
+            .text(@formatSize(message.size))
+        )
         $("#message .views .tab.format").each (i, el) ->
           $el = $(el)
           format = $el.attr("data-message-format")

--- a/views/index.erb
+++ b/views/index.erb
@@ -28,6 +28,7 @@
           <th>To</th>
           <th>Subject</th>
           <th>Received</th>
+          <th>Size</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -45,6 +46,8 @@
         <dd class="to"></dd>
         <dt class="subject">Subject</dt>
         <dd class="subject"></dd>
+        <dt class="size">Size</dt>
+        <dd class="size"></dd>
         <dt class="attachments">Attachments</dt>
         <dd class="attachments"></dd>
       </dl>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6866019/31178608-e4e7f8de-a919-11e7-8a05-b3db6d149ef7.png)
This commits add a new row to the listview and detail page showing the size of the mail, formatted to a readable string.

No tests because #351 is not solved yet.