### PR TITLE
Add TravisCI Build Badge in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MailCatcher
 
+[![Build Status](https://api.travis-ci.org/repos/sj26/mailcatcher.svg?branch=master)](https://travis-ci.org/sj26/mailcatcher)
+
 Catches mail and serves it through a dream.
 
 MailCatcher runs a super simple SMTP server which catches any message sent to it to display in a web interface. Run mailcatcher, set your favourite app to deliver to smtp://127.0.0.1:1025 instead of your default SMTP server, then check out http://127.0.0.1:1080 to see the mail that's arrived so far.


### PR DESCRIPTION
I added a badge of Travis CI.
So that the result of Travis CI can be known from README.
The branch of the target is master.