### PR TITLE
added option --title-prefix to add to the 'MailCatcher' title

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -141,7 +141,7 @@ class MailCatcher
 
   updateMessagesCount: ->
     @favcount.set(@messagesCount())
-    document.title = 'MailCatcher (' + @messagesCount() + ')'
+    document.title = $(document.getElementsByTagName("title")[0]).data('title') + ' (' + @messagesCount() + ')'
 
   tabs: ->
     $("#message ul").children(".tab")

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -90,6 +90,7 @@ module MailCatcher extend self
     :daemon => !windows?,
     :browse => false,
     :quit => true,
+    :title_prefix => ""
   }
 
   def options
@@ -134,6 +135,10 @@ module MailCatcher extend self
 
         parser.on("--no-quit", "Don't allow quitting the process") do
           options[:quit] = false
+        end
+
+        parser.on("--title-prefix TITLE", "Add prefix to the title of the webpage") do |title_prefix|
+          options[:title_prefix] = title_prefix
         end
 
         if mac?

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -17,6 +17,7 @@ module MailCatcher
     class Application < Sinatra::Base
       set :environment, MailCatcher.env
       set :prefix, MailCatcher.options[:http_path]
+      set :title_prefix, MailCatcher.options[:title_prefix]
       set :asset_prefix, File.join(prefix, "assets")
       set :root, File.expand_path("#{__FILE__}/../../../..")
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="mailcatcher">
 <head>
-  <title>MailCatcher</title>
+  <title data-title="<%= settings.title_prefix != '' ? settings.title_prefix + ' ' : '' %>MailCatcher">MailCatcher</title>
   <base href="<%= settings.prefix.chomp("/") %>/">
   <link href="favicon.ico" rel="icon">
   <script src="<%= asset_path("mailcatcher.js") %>"></script>
@@ -9,7 +9,7 @@
 </head>
 <body>
   <header>
-    <h1><a href="http://mailcatcher.me" target="_blank">MailCatcher</a></h1>
+    <h1><%= settings.title_prefix != '' ? settings.title_prefix + ' ' : '' %><a href="http://mailcatcher.me" target="_blank">MailCatcher</a></h1>
     <nav class="app">
       <ul>
         <li class="search"><input type="search" name="search" placeholder="Search messages..." incremental="true" /></li>


### PR DESCRIPTION
This is my first shot at adding an option to change the 'MailCatcher' title to be able to see the difference between multiple mailcatcher instances. I couldn't decide if it only should be an addition that it should be able to replace the whole title. In the end I settled for an addition, as it keeps the 'branding' in place.

See feature: https://github.com/sj26/mailcatcher/issues/320

Please tell me if this is a valid fix for the issue, or that it needs to be done differently.