### PR TITLE
Use docker-compose for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@
 
 # Build gems
 *.gem
+
+# Docker elements
+/deps
+
+# Nodejs
+/bin/node
+/bin/npm
+/bin/phantomjs
+/node_modules
+/package-lock.json

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,7 @@
+# How to contribute
+
+## Using docker + docker-compose
+
+Run `docker-compose up`, it will install all requirements and start mailcatcher that will be available on port 8080 for the web interface and 8025 for smtp.
+
+Run `docker-compose run --rm web ruby2.4 scripts/test` to execute the test suite.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+ruby2.4:
+  image: ruby:2.4.0
+  volumes:
+    - .:/srv
+  working_dir: /srv
+  ports:
+    - "8080:80"
+    - "8025:25"
+  environment:
+    - RUBYLIB=/srv/lib
+    - GEM_PATH=/srv/deps/ruby/2.4.0:/usr/local/lib/ruby/gems/2.4.0:/usr/local/bundle
+    - PATH=/srv/bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  command: ./scripts/web
+
+#ruby2.3:
+#  image: ruby:2.3.0
+#  volumes:
+#    - .:/srv
+#  working_dir: /srv
+#  ports:
+#    - "8180:80"
+#    - "8125:25"
+#  environment:
+#    - RUBYLIB=/srv/lib
+#    - GEM_PATH=/srv/deps/ruby/2.3.0:/usr/local/lib/ruby/gems/2.3.0:/usr/local/bundle
+#    - PATH=/srv/bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+#  command: ./scripts/web

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e # exit if any commands returns a non-zero exit code.
+
+cd "$(dirname "$0")/.." # cd into project root.
+
+NODE_VERSION="8.11.1"
+PHANTOMJS_VERSION="2.1.1"
+
+function node_installed?() {
+  node --version || return 1
+  return 0
+}
+
+function install_node() {
+  wget --no-verbose https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -O /tmp/node.tar.zx
+  tar -xJf /tmp/node.tar.zx -C deps
+  ln -fns $(pwd)/deps/node-v${NODE_VERSION}-linux-x64/bin/{node,npm} bin/
+}
+
+function phantomjs_installed?() {
+  phantomjs --version || return 1
+  return 0
+}
+
+function install_phantomjs() {
+  npm install --unsafe-perm phantomjs@${PHANTOMJS_VERSION}
+  ln -fns $(pwd)/node_modules/.bin/phantomjs bin/
+}
+
+mkdir -p deps
+node_installed? || install_node
+phantomjs_installed? || install_phantomjs
+
+bundle install --path deps

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e # exit if any commands returns a non-zero exit code.
+
+cd "$(dirname "$0")/.." # cd into project root.
+
+./scripts/setup
+
+bundle exec rake

--- a/scripts/web
+++ b/scripts/web
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e # exit if any commands returns a non-zero exit code.
+
+cd "$(dirname "$0")/.." # cd into project root.
+
+./scripts/setup
+
+bundle exec rake assets
+bundle exec mailcatcher --ip 0.0.0.0 --http-port 80 --smtp-port 25 --foreground $@

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -42,6 +42,7 @@ describe MailCatcher do
 
   def deliver_example(name, options={})
     deliver(read_example(name), options)
+    navigate
   end
 
   def selenium


### PR DESCRIPTION
# Context
Setup `docker-compose` environment for local development.

# Why
So local usage and all dependencies installation become as simple as running: `docker-compose up`.

This command will make docker run `ruby2.4` on script `scripts/web` that will install all requirements then start `mailcatcher`, that will be available on port 8080 (web) et 8025 (smtp).

Test suite can be run by using `docker-compose run --rm ruby2.4 scripts/test`, that will install all requirements then run `rake`.

# Additionnal informations

## /deps
The setup use `deps` as directory to keep dependencies docker execution after docker execution (so we do not reinstall `nodejs`, `phantomjs` and `gem` dependencies at each `docker-compose up`).

## Ruby version
Remove `1.9.3` from test:
- because it is no more a maintained version
- due to minimum requirement for `selenium-webdriver` 

## Tests
Sounds like tests are failing due to some race condition, so I forced the navigation after delivering mail.

## Dependencies
Finally this PR fix versions for:
- `selenium-webdriver` due to the fact that phantomjs is no more supported by selenium webdriver since version `3.8`
- `compass` due to the error: `NoMethodError: undefined method 'has?' for Sass::Util:Module`