### PR TITLE
Creating script under recent rvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Instead, pop a note in your README stating you use mailcatcher, and to run `gem 
 
 ### RVM
 
-Under RVM your mailcatcher command may only be available under the ruby you install mailcatcher into. To prevent this, and to prevent gem conflicts, install mailcatcher into a dedicated gemset and create wrapper scripts:
+Under RVM your mailcatcher command may only be available under the ruby you install mailcatcher into. To prevent this, and to prevent gem conflicts, install mailcatcher into a dedicated gemset and for convenience create a link to a wrapper scripts (YMMV depending on OS):
 
     rvm default@mailcatcher --create do gem install mailcatcher
-    rvm wrapper default@mailcatcher --no-prefix mailcatcher catchmail
+    ln -s `rvm default@mailcatcher do rvm wrapper show mailcatcher` ~/.rvm/bin/mailcatcher
 
 ### Rails
 


### PR DESCRIPTION
It seems that rvm wrappers are now automatically created and the `rvm wrapper` command has less functionality (in particular there seems to be no way to generate a --no-prefix wrapper). However the same effect can be made with a simple symlink.