### PR TITLE
Use MidiSmtpServer for incoming SMTP Service - Enables AUTH and STARTTLS

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -179,14 +179,6 @@ module MailCatcher extend self
     # Stash them away for later
     @@options = options
 
-    # daemonize mode, reap the child automatically to prevent zombie
-    if options[:daemon] && pid = fork
-      Process.detach(pid)
-      # wait a second to make sure that all output is send before exit
-      sleep 2
-      exit
-    end
-
     # If we're running in the foreground sync the output.
     unless options[:daemon]
       $stdout.sync = $stderr.sync = true
@@ -231,6 +223,11 @@ module MailCatcher extend self
           $stdin.reopen "/dev/null"
           $stdout.reopen "/dev/null", "a"
           $stderr.reopen '/dev/null', 'a'
+          # daemonize mode, reap the child automatically to prevent zombie
+          if pid = fork
+            Process.detach(pid)
+            exit
+          end
         end
       end
     end

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -121,6 +121,10 @@ module MailCatcher extend self
           options[:smtp_port] = port
         end
 
+        parser.on("--smtp-tls", "Enable tls for the smtp server") do
+          options[:smtp_tls] = true
+        end
+
         parser.on("--http-ip IP", "Set the ip address of the http server") do |ip|
           options[:http_ip] = ip
         end
@@ -193,7 +197,10 @@ module MailCatcher extend self
     EventMachine.run do
       # Set up  MidiSmtpServer server to run within EventMachine loop
       rescue_port options[:smtp_port] do
-        Smtp.new(options[:smtp_port], options[:smtp_ip], 4, { logger_severity: development? ? 0:9 }).start
+        midi_smtp_server_opts = {}
+        midi_smtp_server_opts[:tls_mode] = :TLS_OPTIONAL if options[:smtp_tls]
+        midi_smtp_server_opts[:logger_severity] = development? ? 0:9
+        Smtp.new(options[:smtp_port], options[:smtp_ip], 4, midi_smtp_server_opts).start
         puts "==> #{smtp_url}"
       end
 

--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -9,6 +9,7 @@ class MailCatcher::Smtp < MidiSmtpServer::Smtpd
     opts[:io_cmd_timeout] = nil
     opts[:auth_mode] = :AUTH_OPTIONAL
     opts[:pipelining_extension] = true
+    opts[:internationalization_extensions] = true
     # initialize MidiSmtpServer::Smtpd
     super ports, hosts, max_processings, opts
   end

--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -7,7 +7,6 @@ class MailCatcher::Smtp < MidiSmtpServer::Smtpd
   def initialize(ports = DEFAULT_SMTPD_PORT, hosts = DEFAULT_SMTPD_HOST, max_processings = DEFAULT_SMTPD_MAX_PROCESSINGS, opts = {})
     # set compatible modes and enable optional TLS and AUTH per default
     opts[:io_cmd_timeout] = nil
-    opts[:tls_mode] = :TLS_OPTIONAL
     opts[:auth_mode] = :AUTH_OPTIONAL
     opts[:pipelining_extension] = true
     # initialize MidiSmtpServer::Smtpd

--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -1,55 +1,42 @@
-require "eventmachine"
+require "midi-smtp-server"
 
 require "mail_catcher/mail"
 
-class MailCatcher::Smtp < EventMachine::Protocols::SmtpServer
-  # We override EM's mail from processing to allow multiple mail-from commands
-  # per [RFC 2821](http://tools.ietf.org/html/rfc2821#section-4.1.1.2)
-  def process_mail_from sender
-    if @state.include? :mail_from
-      @state -= [:mail_from, :rcpt, :data]
-      receive_reset
+class MailCatcher::Smtp < MidiSmtpServer::Smtpd
+
+  def initialize(ports = DEFAULT_SMTPD_PORT, hosts = DEFAULT_SMTPD_HOST, max_processings = DEFAULT_SMTPD_MAX_PROCESSINGS, opts = {})
+    # set compatible modes and enable optional TLS and AUTH per default
+    opts[:io_cmd_timeout] = nil
+    opts[:tls_mode] = :TLS_OPTIONAL
+    opts[:auth_mode] = :AUTH_OPTIONAL
+    opts[:pipelining_extension] = true
+    # initialize MidiSmtpServer::Smtpd
+    super ports, hosts, max_processings, opts
+  end
+
+  def on_auth_event(ctx, authorization_id, authentication_id, authentication)
+    # simply allow any combination of user and password
+    if authentication_id != '' && authentication != ''
+      # simulate successful authentification
+      return 'mailcatcher'
     end
-
-    super
+    # otherwise exit with authentification exception
+    raise MidiSmtpServer::Smtpd535Exception
   end
 
-  def current_message
-    @current_message ||= {}
-  end
-
-  def receive_reset
-    @current_message = nil
-    true
-  end
-
-  def receive_sender(sender)
-    current_message[:sender] = sender
-    true
-  end
-
-  def receive_recipient(recipient)
-    current_message[:recipients] ||= []
-    current_message[:recipients] << recipient
-    true
-  end
-
-  def receive_data_chunk(lines)
-    current_message[:source] ||= ""
-    lines.each do |line|
-      current_message[:source] << line << "\r\n"
-    end
-    true
-  end
-
-  def receive_message
+  def on_message_data_event(ctx)
+    # build current_message from ctx values
+    current_message = {}
+    current_message[:sender] = ctx[:envelope][:from]
+    current_message[:recipients] = ctx[:envelope][:to]
+    current_message[:source] = ctx[:message][:data]
+    # append to MailCatcher
     MailCatcher::Mail.add_message current_message
     puts "==> SMTP: Received message from '#{current_message[:sender]}' (#{current_message[:source].length} bytes)"
-    true
   rescue => exception
     MailCatcher.log_exception("Error receiving message", @current_message, exception)
-    false
-  ensure
-    @current_message = nil
+    # re-raise to signal error to smtp client
+    raise
   end
+
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency "midi-smtp-server", "~> 2.3.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"


### PR DESCRIPTION
  - allows optional TLS and AUTH for SMTP Clients
  - SSL cert will be generated temporarily
  - all auth credentials will be accepted

I hope this will make it in your project. It helps to test and work also with clients that send only via SSL/TLS or needs an authentification.

Thanks for any comments
Tom