### PR TITLE
Support UTF8 source

### DIFF
--- a/examples/multipartmail-with-utf8
+++ b/examples/multipartmail-with-utf8
@@ -1,0 +1,19 @@
+To: Blah <blah@blah.com>
+From: Me <me@sj26.com>
+Subject: Test Multipart UTF8 Mail
+Mime-Version: 1.0
+Content-Type: multipart/alternative; boundary=BOUNDARY--198849662
+
+Header
+
+--BOUNDARY--198849662
+Content-Type: text/plain
+
+Plain text mail
+
+--BOUNDARY--198849662
+Content-Type: text/html
+
+<html><body><em>© HTML</em> mail</body></html>
+
+--BOUNDARY--198849662--

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -53,7 +53,7 @@ module MailCatcher::Mail extend self
     end
 
     EventMachine.next_tick do
-      message = MailCatcher::Mail.message message_id
+      message = MailCatcher::Mail.message_without_source(message_id)
       MailCatcher::Events::MessageAdded.push message
     end
   end
@@ -82,6 +82,12 @@ module MailCatcher::Mail extend self
     row = @message_query.execute(id).next
     row && Hash[row.fields.zip(row)].tap do |message|
       message["recipients"] &&= JSON.parse(message["recipients"])
+    end
+  end
+
+  def message_without_source(id)
+    message(id).tap do |m|
+      m.delete("source")
     end
   end
 

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -87,7 +87,7 @@ module MailCatcher
 
       get "/messages/:id.json" do
         id = params[:id].to_i
-        if message = Mail.message(id)
+        if message = Mail.message_without_source(id)
           content_type :json
           JSON.generate(message.merge({
             "formats" => [

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -87,7 +87,7 @@ module MailCatcher
 
       get "/messages/:id.json" do
         id = params[:id].to_i
-        if message = Mail.message_without_source(id)
+        if message = Mail.message(id)
           content_type :json
           JSON.generate(message.merge({
             "formats" => [
@@ -132,9 +132,9 @@ module MailCatcher
 
       get "/messages/:id.source" do
         id = params[:id].to_i
-        if message = Mail.message(id)
+        if message_source = Mail.message_source(id)
           content_type "text/plain"
-          message["source"]
+          message_source
         else
           not_found
         end
@@ -142,9 +142,9 @@ module MailCatcher
 
       get "/messages/:id.eml" do
         id = params[:id].to_i
-        if message = Mail.message(id)
+        if message_source = Mail.message_source(id)
           content_type "message/rfc822"
-          message["source"]
+          message_source
         else
           not_found
         end

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -210,6 +210,47 @@ describe MailCatcher do
     body_element.text.must_include "<em>HTML</em> mail"
   end
 
+  it "catches and displays a multipart UTF8 message as text, html and source" do
+    deliver_example("multipartmail-with-utf8")
+
+    message_from_element.text.must_include DEFAULT_FROM
+    message_to_element.text.must_include DEFAULT_TO
+    message_subject_element.text.must_equal "Test Multipart UTF8 Mail"
+    Time.parse(message_received_element.text).must_be_close_to Time.now, 5
+
+    message_row_element.click
+
+    source_tab_element.displayed?.must_equal true
+    plain_tab_element.displayed?.must_equal true
+    html_tab_element.displayed?.must_equal true
+
+    plain_tab_element.click
+
+    iframe_element.displayed?.must_equal true
+    iframe_element.attribute(:src).must_match /\.plain\Z/
+
+    selenium.switch_to.frame(iframe_element)
+
+    body_element.text.must_include "Plain text mail"
+    body_element.text.wont_include "HTML mail"
+    body_element.text.wont_include "Content-Type: multipart/alternative; boundary=BOUNDARY--198849662"
+
+    selenium.switch_to.default_content
+    html_tab_element.click
+    selenium.switch_to.frame(iframe_element)
+
+    body_element.text.must_include "HTML mail"
+    body_element.text.wont_include "Content-Type: multipart/alternative; boundary=BOUNDARY--198849662"
+
+    selenium.switch_to.default_content
+    source_tab_element.click
+    selenium.switch_to.frame(iframe_element)
+
+    body_element.text.must_include "Content-Type: multipart/alternative; boundary=BOUNDARY--198849662"
+    body_element.text.must_include "Plain text mail"
+    body_element.text.must_include "<em>© HTML</em> mail"
+  end
+
   it "catches and displays an unknown message as source" do
     deliver_example("unknownmail")
 


### PR DESCRIPTION
The places where mailcatcher tries to JSON-encode a message it fails if the message source is UTF8 encoded.
To get around this issue we can just leave out the source because it is not being used in the places where messages are JSON-encoded.

---

Backtraces of when the error occurred when receiving an email containing an EM DASH:

```
*** Error sending message through websocket: {"id"=>1, [...] }
    Exception: "\xE2" from ASCII-8BIT to UTF-8
    Backtrace:
       /Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `encode'
       /Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
       /Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
       mailcatcher (0.6.5) lib/mail_catcher/web/application.rb:69:in `block (3 levels) in <class:Application>'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `block (3 levels) in push'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `each'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `block (2 levels) in push'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `each'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `block in push'
       eventmachine (1.0.9.1) lib/eventmachine.rb:256:in `schedule'
       eventmachine (1.0.9.1) lib/em/channel.rb:43:in `push'
       mailcatcher (0.6.5) lib/mail_catcher/mail.rb:57:in `block in add_message'
       eventmachine (1.0.9.1) lib/eventmachine.rb:981:in `block in run_deferred_callbacks'
       eventmachine (1.0.9.1) lib/eventmachine.rb:978:in `times'
       eventmachine (1.0.9.1) lib/eventmachine.rb:978:in `run_deferred_callbacks'
       eventmachine (1.0.9.1) lib/eventmachine.rb:193:in `run_machine'
       eventmachine (1.0.9.1) lib/eventmachine.rb:193:in `run'
       mailcatcher (0.6.5) lib/mail_catcher.rb:173:in `run!'
       mailcatcher (0.6.5) bin/mailcatcher:5:in `<top (required)>'
       /Users/otoy/.rbenv/versions/2.5.1/bin/mailcatcher:23:in `load'
       /Users/otoy/.rbenv/versions/2.5.1/bin/mailcatcher:23:in `<main>'
    Please submit this as an issue at http://github.com/sj26/mailcatcher/issues
```

```
2019-02-12 17:28:34 - Encoding::UndefinedConversionError - "\xE2" from ASCII-8BIT to UTF-8:
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `encode'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/mailcatcher-0.6.5/lib/mail_catcher/web/application.rb:94:in `block in <class:Application>'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `block in compile!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (3 levels) in route!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:994:in `route_eval'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (2 levels) in route!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1015:in `block in process_route'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `catch'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `process_route'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:973:in `block in route!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `each'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `route!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1085:in `block in dispatch!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1082:in `dispatch!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `block in call!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `call!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:895:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/xss_header.rb:18:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/path_traversal.rb:16:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/json_csrf.rb:18:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-protection-1.5.5/lib/rack/protection/frame_options.rb:31:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/nulllogger.rb:9:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/head.rb:13:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:182:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:2013:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `block in call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1787:in `synchronize'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/urlmap.rb:66:in `block in call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/urlmap.rb:50:in `each'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/urlmap.rb:50:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-1.6.11/lib/rack/builder.rb:153:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/mailcatcher-0.6.5/lib/mail_catcher/web.rb:19:in `call'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thin-1.5.1/lib/thin/connection.rb:81:in `block in pre_process'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thin-1.5.1/lib/thin/connection.rb:79:in `catch'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thin-1.5.1/lib/thin/connection.rb:79:in `pre_process'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thin-1.5.1/lib/thin/connection.rb:54:in `process'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thin-1.5.1/lib/thin/connection.rb:39:in `receive_data'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run_machine'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/mailcatcher-0.6.5/lib/mail_catcher.rb:173:in `run!'
	/Users/otoy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/mailcatcher-0.6.5/bin/mailcatcher:5:in `<top (required)>'
	/Users/otoy/.rbenv/versions/2.5.1/bin/mailcatcher:23:in `load'
	/Users/otoy/.rbenv/versions/2.5.1/bin/mailcatcher:23:in `<main>'
```