### PR TITLE
& should be escaped in plain text

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -277,6 +277,7 @@ class MailCatcher
         message_iframe = $("#message iframe").contents()
         text = message_iframe.text()
         text = text.replace(/((http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?)/g, """<a href="$1" target="_blank">$1</a>""")
+        text = text.replace(/&/g, "&amp;")
         text = text.replace(/\n/g, "<br/>")
         message_iframe.find("html").html("<html><body>#{text}</html></body>")
 

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -276,9 +276,11 @@ class MailCatcher
       when "plain"
         message_iframe = $("#message iframe").contents()
         text = message_iframe.text()
-        text = text.replace(/((http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?)/g, """<a href="$1" target="_blank">$1</a>""")
         text = text.replace(/&/g, "&amp;")
+        text = text.replace(/</g, "&lt;")
+        text = text.replace(/>/g, "&gt;")
         text = text.replace(/\n/g, "<br/>")
+        text = text.replace(/((http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?)/g, """<a href="$1" target="_blank">$1</a>""")
         message_iframe.find("html").html("<html><body>#{text}</html></body>")
 
   refresh: ->


### PR DESCRIPTION
Thank you very much for your great tool.
We had a trouble on debugging mails in plain text because a mistaken "&amp;nbsp;" string wasn't shown.
"&" should be replaced as "&amp;amp;". I confirmed it by myself but please check it by yourself.
I guess, '<' and '>' and others should be considered this way.
