### PR TITLE
Add --http-path support for attachment downloads

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -244,7 +244,7 @@ class MailCatcher
           $ul = $("<ul/>").appendTo($("#message .metadata dd.attachments").empty())
 
           $.each message.attachments, (i, attachment) ->
-            $ul.append($("<li>").append($("<a>").attr("href", attachment["href"]).addClass(attachment["type"].split("/", 1)[0]).addClass(attachment["type"].replace("/", "-")).text(attachment["filename"])))
+            $ul.append($("<li>").append($("<a>").attr("href", "messages/#{id}/parts/#{attachment["cid"]}").addClass(attachment["type"].split("/", 1)[0]).addClass(attachment["type"].replace("/", "-")).text(attachment["filename"])))
           $("#message .metadata .attachments").show()
         else
           $("#message .metadata .attachments").hide()

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -253,8 +253,6 @@ class MailCatcher
 
         @loadMessageBody()
 
-  # XXX: These should probably cache their iframes for the current message now we're using a remote service:
-
   loadMessageBody: (id, format) ->
     id ||= @selectedMessage()
     format ||= $("#message .views .tab.format.selected").attr("data-message-format")

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -97,9 +97,7 @@ module MailCatcher
               ("html" if Mail.message_has_html? id),
               ("plain" if Mail.message_has_plain? id)
             ].compact,
-            "attachments" => Mail.message_attachments(id).map do |attachment|
-              attachment.merge({"href" => "#{settings.prefix}/messages/#{escape(id)}/parts/#{escape(attachment["cid"])}"})
-            end,
+            "attachments" => Mail.message_attachments(id),
           }))
         else
           not_found

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -98,7 +98,7 @@ module MailCatcher
               ("plain" if Mail.message_has_plain? id)
             ].compact,
             "attachments" => Mail.message_attachments(id).map do |attachment|
-              attachment.merge({"href" => "/messages/#{escape(id)}/parts/#{escape(attachment["cid"])}"})
+              attachment.merge({"href" => "#{settings.prefix}/messages/#{escape(id)}/parts/#{escape(attachment["cid"])}"})
             end,
           }))
         else


### PR DESCRIPTION
Hi,

First, thanks for this tool :)

Now, the `--http-path` option was not handled for the attachments downloads.
This small fix corrects this.