### PR TITLE
Add support for emulating the mailgun HTTP api

### DIFF
--- a/lib/mail_catcher/mailgun.rb
+++ b/lib/mail_catcher/mailgun.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rack/builder"
+
+require "mail"
+
+module MailCatcher
+  class Application < Sinatra::Base
+    set :environment, MailCatcher.env
+    get "/" do
+      'ok'
+    end
+
+    get "/count" do
+      messages = MailCatcher::Mail.messages
+      puts "*** message count #{messages.count}"
+      {count: messages.count}.to_json
+    end
+
+    post "/v3/:domain/messages" do
+      puts "mailgun from: #{params[:from]} to: #{params[:to]}, subject: #{params[:subject]}"
+      mail = ::Mail.new do |mail|
+        mail.to params[:to]
+        mail.from params[:from]
+        mail.subject params[:subject]
+        mail.text_part do |part|
+          part.body params[:text]
+        end
+        mail.html_part do |part|
+          part.body params[:html]
+        end
+      end
+      MailCatcher::Mail.add_message(
+        sender: params[:from],
+        recipients: params[:to],
+        source: mail.to_s
+      )
+      status 201
+    end
+
+    not_found do
+      puts "*** 404 at #{request.path} ***"
+    end
+  end
+  module Mailgun extend self
+    def app
+      @@app ||= Rack::Builder.new do
+        map('/') do
+          run Application
+        end
+      end
+    end
+
+    def call(env)
+      app.call(env)
+    end
+  end
+end


### PR DESCRIPTION
Mailgun is an email service provider, recommending you send email messages via http rather than smtp.

This feature adds functionality to mailcatcher so that it implements the mailgun API, allowing a (in my case rails) application to be configured to think it's delivering to mailgun over http, but in fact delivering to mailcatcher.

To configure a rails on localhost to talk to mailcatcher also on localhost (here, picking port 3025):

In rails `development.rb`:
```
config.action_mailer.mailgun_settings = {
  api_key: 'dontcare',
  domain: 'example.com',
  api_host: 'localhost:3025',
  api_ssl: false
}
```

Then run mailcatcher as:
```
bundle exec bin/mailcatcher --mailgun-ip '127.0.0.1' --mailgun-port 3025 -f
```