### PR TITLE
Update to recent Thin 1.7 and Eventmachine 1.2 releases

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,12 +32,12 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency "eventmachine", "~> 1.2"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.5.0"
+  s.add_dependency "thin", "~> 1.7"
   s.add_dependency "skinny", "~> 0.2.3"
 
   s.add_development_dependency "coffee-script"


### PR DESCRIPTION
I recently received an issue on the Eventmachine tracker asking how to build EM 1.0.9.1 on a recent version of MacOS. The fellow as looking to install the latest MailCatcher gem. I hope that updating to recent versions of Eventmachine and Thin will go smoothly for MailCatcher!