### PR TITLE
Upgrade/thin skinny em

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "skinny", github: "montdidier/skinny", branch: "upgrade/eventmachine-thin"
+
 gemspec
 
 # mime-types 3+, required by mail, requires ruby 2.0+

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -233,7 +233,7 @@ module MailCatcher extend self
   end
 
   def quit!
-    EventMachine.next_tick { EventMachine.stop }
+    EventMachine.next_tick { EventMachine.stop_event_loop }
   end
 
 protected

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -200,9 +200,8 @@ module MailCatcher extend self
     EventMachine.run do
       # Set up an SMTP server to run within EventMachine
       rescue_port options[:smtp_port] do
-        puts "\n"
         EventMachine.start_server options[:smtp_ip], options[:smtp_port], Smtp
-        puts "==> #{smtp_url}"
+        puts "\n==> #{smtp_url}"
       end
 
       # Let Thin set itself up inside our EventMachine loop

--- a/lib/mail_catcher/tcpserver.rb
+++ b/lib/mail_catcher/tcpserver.rb
@@ -1,0 +1,32 @@
+module MailCatcher
+  class TcpServer < Thin::Backends::Base
+    # Address and port on which the server is listening for connections.
+    attr_accessor :socket
+
+    def initialize(host, port, options)
+      @host = host
+      @port = port
+      @socket = options.fetch(:socket)
+      super()
+    end
+
+    # Connect the server
+    def connect
+      @signature = EventMachine.attach_server(@socket, Thin::Connection, &method(:initialize_connection))
+      binary_name = EventMachine.get_sockname(@signature)
+      port_name = Socket.unpack_sockaddr_in(binary_name)
+      @port = port_name[0]
+      @host = port_name[1]
+      @signature
+    end
+
+    # Stops the server
+    def disconnect
+      EventMachine.stop_server(@signature)
+    end
+
+    def to_s
+      "#{@host}:#{@port}"
+    end
+  end
+end

--- a/lib/mail_catcher/tcpserver.rb
+++ b/lib/mail_catcher/tcpserver.rb
@@ -1,7 +1,6 @@
 module MailCatcher
   class TcpServer < Thin::Backends::Base
     # Address and port on which the server is listening for connections.
-    attr_accessor :socket
 
     def initialize(host, port, options)
       @host = host

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,23 +32,23 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency "eventmachine", "1.2"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.5.0"
-  s.add_dependency "skinny", "~> 0.2.3"
+  s.add_dependency "thin", "~> 1.8"
+  s.add_dependency "skinny", "~> 0.2.5"
 
-  s.add_development_dependency "coffee-script"
+  s.add_development_dependency "coffee-script", '~> 2.4'
   s.add_development_dependency "compass", "~> 1.0.3"
   s.add_development_dependency "minitest", "~> 5.0"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rdoc"
-  s.add_development_dependency "sass"
+  s.add_development_dependency "rake", '~> 13.0'
+  s.add_development_dependency "rdoc", '~> 6.0'
+  s.add_development_dependency "sass", '~> 3.4'
   s.add_development_dependency "selenium-webdriver", "~> 3.7"
-  s.add_development_dependency "sprockets"
-  s.add_development_dependency "sprockets-sass"
-  s.add_development_dependency "sprockets-helpers"
-  s.add_development_dependency "uglifier"
+  s.add_development_dependency "sprockets", '~> 3.7'
+  s.add_development_dependency "sprockets-sass", '>= 2.0.0.beta2', '< 3'
+  s.add_development_dependency "sprockets-helpers", '~> 1.4'
+  s.add_development_dependency "uglifier", '~> 4.2'
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "eventmachine", "1.2"
+  s.add_dependency "eventmachine", "~> 1.2"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"


### PR DESCRIPTION
Update to thin 1.8 (will compile under Xcode 12) and event machine 1.2 

Some of the changes to make this possible include. 

- Moving `Process.daemon` to before the the eventmachine loop
- Handle signals in mailcatcher (changes in thin made this necessary)
- Removed the explicit gem activations which I don't think are necessary (anymore?)
- Removed the EventMachine monkey patch which should not be necessary anymore
- Added some constraints on dependencies

Depends on https://github.com/sj26/skinny/pull/8

Should supersede https://github.com/sj26/mailcatcher/pull/431