### PR TITLE
Adding curl command to stop MailCatcher

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -227,7 +227,7 @@ module MailCatcher extend self
       if options[:daemon]
         EventMachine.next_tick do
           if quittable?
-            puts "*** MailCatcher runs as a daemon by default. Go to the web interface to quit."
+            puts "*** MailCatcher runs as a daemon by default. Go to the web interface to quit, or use: curl -X DELETE http://127.0.0.1:1080/"
           else
             puts "*** MailCatcher is now running as a daemon that cannot be quit."
           end


### PR DESCRIPTION
See https://github.com/sj26/mailcatcher/issues/167 and https://github.com/sj26/mailcatcher/issues/387
Please replace `http://127.0.0.1:1080/` with the actual address (I guess it's `options[:http_ip]` and `options[:http_port]`) - I don't know how to do that in ... - which language is it at all? Ruby? ;-)