### PR TITLE
Foreign key constraints are not active by default.

### DIFF
--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -153,7 +153,7 @@ module MailCatcher::Mail extend self
   end
 
   def delete!
-    @delete_all_messages_query ||= db.prepare "DELETE FROM message"
+    @delete_all_messages_query ||= db.prepare "PRAGMA foreign_keys = ON;DELETE FROM message"
     @delete_all_messages_query.execute
 
     EventMachine.next_tick do
@@ -162,7 +162,7 @@ module MailCatcher::Mail extend self
   end
 
   def delete_message!(message_id)
-    @delete_messages_query ||= db.prepare "DELETE FROM message WHERE id = ?"
+    @delete_messages_query ||= db.prepare "PRAGMA foreign_keys = ON;DELETE FROM message WHERE id = ?"
     @delete_messages_query.execute(message_id)
 
     EventMachine.next_tick do


### PR DESCRIPTION
see [#450](https://github.com/sj26/mailcatcher/issues/450)
From [Official Doc](https://www.sqlite.org/foreignkeys.html) :

> 2. **Enabling Foreign Key Support**
> Assuming the library is compiled with foreign key constraints enabled, it must still be enabled by the application at runtime, using the PRAGMA foreign_keys command. For example:
> 
>     `sqlite> PRAGMA foreign_keys = ON;`
> 
> Foreign key constraints are disabled by default (for backwards compatibility), so must be enabled separately for each database connection.