### PR TITLE
Allow HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ MailCatcher v0.8.0
         --smtp-port PORT             Set the port of the smtp server
         --http-ip IP                 Set the ip address of the http server
         --http-port PORT             Set the port address of the http server
+        --http-basic-auth-username   Set the username for HTTP Basic Authentication
+        --http-basic-auth-password   Set the password for HTTP Basic Authentication
         --messages-limit COUNT       Only keep up to COUNT most recent messages
         --http-path PATH             Add a prefix to all HTTP paths
         --no-quit                    Don't allow quitting the process

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -70,6 +70,8 @@ module MailCatcher extend self
     :http_ip => "127.0.0.1",
     :http_port => "1080",
     :http_path => "/",
+    :http_basic_auth_username => nil,
+    :http_basic_auth_password => nil,
     :messages_limit => nil,
     :verbose => false,
     :daemon => !windows?,
@@ -83,6 +85,10 @@ module MailCatcher extend self
 
   def quittable?
     options[:quit]
+  end
+
+  def use_http_basic_auth?
+    !!options[:http_basic_auth_username] && !!options[:http_basic_auth_password]
   end
 
   def parse! arguments=ARGV, defaults=@defaults
@@ -112,6 +118,21 @@ module MailCatcher extend self
 
         parser.on("--http-port PORT", Integer, "Set the port address of the http server") do |port|
           options[:http_port] = port
+        end
+
+        parser.on("--http-basic-auth-username USERNAME", String, "Set the HTTP Basic Auth username") do |username|
+          options[:http_basic_auth_username] = username
+        end
+
+        parser.on("--http-basic-auth-password [PASSWORD]",  "Set the HTTP Basic Auth password. Leave blank to enter securely.") do |password|
+          if password.nil?
+            require 'io/console'
+
+            puts "Please provide the HTTP Basic Auth password:"
+            password = STDIN.getpass
+          end
+
+          options[:http_basic_auth_password] = password
         end
 
         parser.on("--messages-limit COUNT", Integer, "Only keep up to COUNT most recent messages") do |count|

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -22,6 +22,12 @@ module MailCatcher
       set :asset_prefix, File.join(prefix, "assets")
       set :root, File.expand_path("#{__FILE__}/../../../..")
 
+      if MailCatcher.use_http_basic_auth?
+        use Rack::Auth::Basic do |username, password|
+          username == MailCatcher.options[:http_basic_auth_username] && password == MailCatcher.options[:http_basic_auth_password]
+        end
+      end
+
       if development?
         require "sprockets-helpers"
 


### PR DESCRIPTION
This adds 2 options: `http_basic_auth_username` and
`http_basic_auth_password` which when passed adds HTTP Basic
Authentication to the web frontend.

For those who just want to deploy some quick basic auth rather than creating a proxy server

Websockets are tested & working. We are actively using this fork in our staging environment