### PR TITLE
REFACTOR: Use Async and family

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -23,19 +23,19 @@ require 'async/io/shared_endpoint'
 require 'mail'
 require 'falcon'
 
-require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/message'
-require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/version'
+# require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/message'
+# require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/version'
 
-# require 'mail_catcher/message'
-# require 'mail_catcher/version'
+require 'mail_catcher/message'
+require 'mail_catcher/version'
 
 module MailCatcher extend self
-  autoload :Mail, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/mail'
-  autoload :SMTP, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/smtp'
-  autoload :Web, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/web'
-  # autoload :Mail, "mail_catcher/mail"
-  # autoload :Smtp, "mail_catcher/smtp"
-  # autoload :Web, "mail_catcher/web"
+  # autoload :Mail, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/mail'
+  # autoload :SMTP, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/smtp'
+  # autoload :Web, '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/web'
+  autoload :Mail, "mail_catcher/mail"
+  autoload :SMTP, "mail_catcher/smtp"
+  autoload :Web, "mail_catcher/web"
 
   def env
     ENV.fetch("MAILCATCHER_ENV", "production")

--- a/lib/mail_catcher/bus.rb
+++ b/lib/mail_catcher/bus.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require "eventmachine"
-
-module MailCatcher
-  Bus = EventMachine::Channel.new
-end

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "eventmachine"
 require "json"
 require "mail"
 require "sqlite3"
+require 'async/websocket/client'
 
 module MailCatcher::Mail extend self
   def db
@@ -56,10 +56,7 @@ module MailCatcher::Mail extend self
       add_message_part(message_id, cid, part.mime_type || "text/plain", part.attachment? ? 1 : 0, part.filename, part.charset, body, body.length)
     end
 
-    EventMachine.next_tick do
-      message = MailCatcher::Mail.message message_id
-      MailCatcher::Bus.push(type: "add", message: message)
-    end
+    MailCatcher.send_data(type: 'add', message: message(message_id))
   end
 
   def add_message_part(*args)
@@ -157,18 +154,14 @@ module MailCatcher::Mail extend self
     @delete_all_messages_query ||= db.prepare "DELETE FROM message"
     @delete_all_messages_query.execute
 
-    EventMachine.next_tick do
-      MailCatcher::Bus.push(type: "clear")
-    end
+    MailCatcher.send_data(type: 'clear')
   end
 
   def delete_message!(message_id)
     @delete_messages_query ||= db.prepare "DELETE FROM message WHERE id = ?"
     @delete_messages_query.execute(message_id)
 
-    EventMachine.next_tick do
-      MailCatcher::Bus.push(type: "remove", id: message_id)
-    end
+    MailCatcher.send_data(type: 'remove', id: message_id)
   end
 
   def delete_older_messages!(count = MailCatcher.options[:messages_limit])

--- a/lib/mail_catcher/message.rb
+++ b/lib/mail_catcher/message.rb
@@ -1,0 +1,18 @@
+module MailCatcher
+  def send_data(data)
+    Async do
+      endpoint = Async::HTTP::Endpoint.parse("#{MailCatcher.http_url}/messages")
+
+      begin
+        Async::WebSocket::Client.connect(endpoint) do |connection|
+          puts 'Connected...'
+
+          connection.write data
+          connection.flush
+        end
+      rescue Errno::ECONNREFUSED
+        puts 'Cannot connect to the host. Please try again...'
+      end
+    end
+  end
+end

--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -1,58 +1,415 @@
 # frozen_string_literal: true
 
-require "eventmachine"
+module MailCatcher
+  module SMTP
+    require 'uri'
 
-require "mail_catcher/mail"
+    require 'async/io/endpoint'
+    require 'async/io/host_endpoint'
+    require 'async/io/ssl_endpoint'
 
-class MailCatcher::Smtp < EventMachine::Protocols::SmtpServer
-  # We override EM's mail from processing to allow multiple mail-from commands
-  # per [RFC 2821](https://tools.ietf.org/html/rfc2821#section-4.1.1.2)
-  def process_mail_from sender
-    if @state.include? :mail_from
-      @state -= [:mail_from, :rcpt, :data]
-      receive_reset
+    class URLEndpoint < Async::IO::Endpoint
+      def self.parse(string, **options)
+        url = URI.parse(string).normalize
+
+        new(url, **options)
+      end
+
+      def initialize(url, endpoint = nil, **options)
+        super(**options)
+
+        raise ArgumentError, "URL must be absolute (include scheme, host): #{url}" unless url.absolute?
+
+        @url = url
+        @endpoint = endpoint
+      end
+
+      def to_s
+        "\#<#{self.class} #{@url} #{@options.inspect}>"
+      end
+
+      attr :url, :options
+
+      def address
+        endpoint.address
+      end
+
+      def secure?
+        ['smtps'].include?(@url.scheme)
+      end
+
+      def protocol
+        Protocol::SMTP
+      end
+
+      def default_port
+        secure? ? 465 : 25
+      end
+
+      def default_port?
+        port == default_port
+      end
+
+      def port
+        @options[:port] || @url.port || default_port
+      end
+
+      def hostname
+        @options[:hostname] || @url.hostname
+      end
+
+      def scheme
+        @options[:scheme] || @url.scheme
+      end
+
+      def authority
+        if default_port?
+          hostname
+        else
+          "#{hostname}:#{port}"
+        end
+      end
+
+      def path
+        @url.request_uri
+      end
+
+      LOCALHOST = 'localhost'
+
+      # We don't try to validate peer certificates when talking to localhost because they would always be self-signed.
+      def ssl_verify_mode
+        case hostname
+        when LOCALHOST
+          OpenSSL::SSL::VERIFY_NONE
+        else
+          OpenSSL::SSL::VERIFY_PEER
+        end
+      end
+
+      def ssl_context
+        @options[:ssl_context] || ::OpenSSL::SSL::SSLContext.new.tap do |context|
+          context.set_params(
+            verify_mode: ssl_verify_mode
+          )
+        end
+      end
+
+      def tcp_options
+        { reuse_port: @options[:reuse_port] ? true : false }
+      end
+
+      def build_endpoint(endpoint = nil)
+        endpoint ||= Async::IO::Endpoint.tcp(hostname, port, tcp_options)
+
+        if secure?
+          # Wrap it in SSL:
+          return Async::IO::SSLEndpoint.new(endpoint,
+                                            ssl_context: ssl_context,
+                                            hostname: hostname)
+        end
+
+        endpoint
+      end
+
+      def endpoint
+        @endpoint ||= build_endpoint
+      end
+
+      def bind(*args, &block)
+        endpoint.bind(*args, &block)
+      end
+
+      def connect(*args, &block)
+        endpoint.connect(*args, &block)
+      end
+
+      def each
+        return to_enum unless block_given?
+
+        endpoint.each do |endpoint|
+          yield self.class.new(@url, endpoint, @options)
+        end
+      end
+
+      def key
+        [@url.scheme, @url.userinfo, @url.host, @url.port, @options]
+      end
+
+      def eql?(other)
+        key.eql? other.key
+      end
+
+      def hash
+        key.hash
+      end
     end
 
-    super
-  end
+    Envelope = Struct.new(:sender, :recipients, :content)
 
-  def current_message
-    @current_message ||= {}
-  end
+    require 'async/io/protocol/line'
 
-  def receive_reset
-    @current_message = nil
-    true
-  end
+    module Protocol
+      module SMTP
+        def self.server(stream, *args)
+          Server.new(stream, *args)
+        end
 
-  def receive_sender(sender)
-    current_message[:sender] = sender
-    true
-  end
+        class Server < Async::IO::Protocol::Line
+          CR = "\r"
+          LF = "\n"
+          CRLF = "\r\n"
+          SP = ' '
+          COLON = ':'
+          DOT = '.'
 
-  def receive_recipient(recipient)
-    current_message[:recipients] ||= []
-    current_message[:recipients] << recipient
-    true
-  end
+          def initialize(stream, hostname: nil)
+            super(stream, CRLF)
 
-  def receive_data_chunk(lines)
-    current_message[:source] ||= +""
-    lines.each do |line|
-      current_message[:source] << line << "\r\n"
+            @hostname = hostname
+            @state = {}
+          end
+
+          attr :hostname
+
+          def read_line
+            if line = @stream.read_until(LF)
+              line.chomp(CR)
+            else
+              @stream.eof!
+            end
+          end
+
+          alias write_line write_lines
+
+          def write_response(code, *lines, last_line)
+            write_lines(*lines.map { |line| "#{code}-#{line}" },
+                        "#{code} #{last_line}")
+          end
+
+          def each(task: Async::Task.current)
+            write_response 220, 'MailCatcher ready'
+
+            loop do
+              line = read_line
+              command, line = line.split(SP, 2)
+              case command
+              when 'HELO'
+                write_response 250, hostname
+              when 'EHLO'
+                write_response 250, hostname, 'CHUNKING', '8BITMIME', 'BINARYMIME', 'SMTPUTF8'
+              when 'SEND'
+                write_response 502, 'Command not implemented'
+              when 'SOML'
+                write_response 502, 'Command not implemented'
+              when 'SAML'
+                write_response 502, 'Command not implemented'
+              when 'MAIL'
+                from, line = line.split(COLON, 2)
+                unless from == 'FROM'
+                  write_response 500, 'Syntax error, command unrecognized'
+                  next
+                end
+                sender, line = line.split(SP, 2)
+                encoding = nil
+                if line && !line.empty?
+                  line.split(SP).each do |param|
+                    case param
+                    when 'BODY=7BIT'
+                      encoding = :ascii
+                    when 'BODY=8BITMIME'
+                      encoding = :binary
+                    when 'BODY=BINARYMIME'
+                      encoding = :binary
+                    when 'SMTPUTF8'
+                      encoding = :utf8
+                    else
+                      write_response 501, 'Unexpected parameters or arguments'
+                    end
+                  end
+                end
+                @state[:sender] = sender
+                @state[:encoding] = encoding if encoding
+                write_response 250, "New message from: #{sender}"
+              when 'RCPT'
+                unless @state[:sender]
+                  write_response 503, 'Bad sequence of commands'
+                  next
+                end
+                to, line = line.split(COLON, 2)
+                unless to == 'TO'
+                  write_response 501, 'Syntax error in parameters or arguments'
+                  next
+                end
+                recipient, line = line.split(SP, 2)
+                if line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                @state[:recipients] ||= []
+                @state[:recipients] << recipient
+                write_response 250, "Recipient added: #{recipient}"
+              when 'DATA'
+                unless @state[:sender] && @state[:recipients]
+                  write_response 503, 'Bad sequence of commands'
+                  next
+                end
+                if @state.key? :buffer # BDAT
+                  write_response 503, 'Bad sequence of commands'
+                  next
+                end
+                if line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                write_response 354, 'Start mail input; end with <CRLF>.<CRLF>'
+                buffer = ''.b
+                loop do
+                  line = read_line
+                  break if line == DOT
+
+                  line.delete_prefix!(DOT)
+                  buffer << line << CRLF
+                  task.yield
+                end
+                encoding = @state[:encoding]
+                begin
+                  case encoding
+                  when :ascii
+                    buffer.force_encoding(Encoding::ASCII)
+                  when :binary
+                    buffer.force_encoding(Encoding::BINARY)
+                  when :utf8, nil
+                    buffer.force_encoding(Encoding::UTF_8)
+                  end
+                rescue ArgumentError => e
+                  write_response 501, "Incorrect encoding (#{encoding}): #{e}"
+                  @state.clear
+                  next
+                end
+                yield Envelope.new(@state[:sender], @state[:recipients], buffer)
+                @state.clear
+                write_response 250, 'Message sent'
+              when 'BDAT'
+                unless @state[:sender] && @state[:recipients]
+                  write_response 503, 'Bad sequence of commands'
+                  next
+                end
+                size, line = line.split(SP, 2)
+                unless size.to_i.to_s == size
+                  write_response 501, 'Syntax error in parameters or arguments'
+                  next
+                end
+                size = size.to_i
+                last = false
+                if line == 'LAST'
+                  last = true
+                elsif line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                buffer = @state[:buffer] ||= ''.b
+                buffer << read(size)
+                if last
+                  begin
+                    case encoding
+                    when :ascii
+                      buffer.force_encoding(Encoding::ASCII)
+                    when :binary
+                      buffer.force_encoding(Encoding::BINARY)
+                    when :utf8, nil
+                      buffer.force_encoding(Encoding::UTF_8)
+                    end
+                  rescue ArgumentError => e
+                    write_response 500, "Bad encoding: #{e}"
+                    @state.clear
+                    next
+                  end
+                  yield Envelope.new(@state[:sender], @state[:recipients], buffer)
+                  @state.clear
+                  write_response 250, 'Message sent'
+                else
+                  write_response 250, 'Data received'
+                end
+              when 'RSET'
+                if line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                envelope = nil
+                write_response 250, 'OK'
+              when 'NOOP'
+                if line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                write_response 250, 'OK'
+              when 'EXPN'
+                write_response 502, 'Command not implemented'
+              when 'VRFY'
+                write_response 502, 'Command not implemented'
+              when 'HELP'
+                write_response 502, 'Command not implemented'
+              when 'STARTTLS'
+                write_response 502, 'Command not implemented'
+              when 'QUIT'
+                if line && !line.empty?
+                  write_response 501, 'Unexpected parameters or arguments'
+                  next
+                end
+                write_response 221, 'Bye!'
+                close unless closed?
+                return
+              else
+                write_response 500, 'Syntax error, command unrecognized'
+              end
+
+              task.yield
+            end
+
+            close unless closed?
+          end
+        end
+      end
     end
-    true
-  end
 
-  def receive_message
-    MailCatcher::Mail.add_message current_message
-    MailCatcher::Mail.delete_older_messages!
-    puts "==> SMTP: Received message from '#{current_message[:sender]}' (#{current_message[:source].length} bytes)"
-    true
-  rescue => exception
-    MailCatcher.log_exception("Error receiving message", @current_message, exception)
-    false
-  ensure
-    @current_message = nil
+    require 'async'
+    require 'async/task'
+    require 'async/io/stream'
+
+    class Server
+      def initialize(endpoint, protocol = endpoint.protocol)
+        @endpoint = endpoint
+        @protocol = protocol
+
+        define_singleton_method(:call, &proc) if block_given?
+      end
+
+      def accept(peer, address, task: Async::Task.current)
+        Async.logger.debug(self) { "Incoming connnection from #{address.inspect}" }
+
+        stream = Async::IO::Stream.new(peer)
+        protocol = @protocol.server(stream, hostname: @endpoint.hostname)
+
+        protocol.each do |envelope|
+          Async.logger.debug(self) { "Incoming message from #{address.inspect}: #{envelope.inspect}" }
+
+          call(envelope)
+        end
+
+        Async.logger.debug(self) { "Connection from #{address.inspect} closed cleanly" }
+      rescue EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::EPROTOTYPE
+        # Sometimes client will disconnect without completing a result or reading the entire buffer. That means we are done.
+        # Errno::EPROTOTYPE is a bug with Darwin. It happens because the socket is lazily created (in Darwin).
+        Async.logger.debug(self) { "Connection from #{address.inspect} closed: #{$ERROR_INFO}" }
+      end
+
+      def call
+        raise NotImplementedError, 'Supply a block to MailCatcher::SMTP::Server.new or subclass and implement #call'
+      end
+
+      def run
+        @endpoint.accept(&method(:accept))
+      end
+    end
   end
 end

--- a/lib/mail_catcher/version.rb
+++ b/lib/mail_catcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailCatcher
-  VERSION = "0.8.0.beta3"
+  VERSION = "1.0.0.beta1"
 end

--- a/lib/mail_catcher/web.rb
+++ b/lib/mail_catcher/web.rb
@@ -2,8 +2,8 @@
 
 require "rack/builder"
 
-require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/web/application'
-# require "mail_catcher/web/application"
+# require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/web/application'
+require "mail_catcher/web/application"
 
 module MailCatcher
   module Web extend self

--- a/lib/mail_catcher/web.rb
+++ b/lib/mail_catcher/web.rb
@@ -2,7 +2,8 @@
 
 require "rack/builder"
 
-require "mail_catcher/web/application"
+require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/web/application'
+# require "mail_catcher/web/application"
 
 module MailCatcher
   module Web extend self

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -7,8 +7,8 @@ require "uri"
 require "sinatra"
 require 'async/websocket/adapters/rack'
 
-require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/mail'
-# require "mail_catcher/mail"
+# require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/mail'
+require "mail_catcher/mail"
 
 module MailCatcher
   module Web

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -5,18 +5,55 @@ require "net/http"
 require "uri"
 
 require "sinatra"
-require "skinny"
+require 'async/websocket/adapters/rack'
 
-require "mail_catcher/bus"
-require "mail_catcher/mail"
-
-class Sinatra::Request
-  include Skinny::Helpers
-end
+require '/Users/ahmedgagan/Rails Gem/mailcatcher/lib/mail_catcher/mail'
+# require "mail_catcher/mail"
 
 module MailCatcher
   module Web
     class Application < Sinatra::Base
+      def initialize
+        super
+        @connections = Set.new
+        @semaphore = Async::Semaphore.new(512)
+
+        @count = 0
+      end
+
+      def connect(connection)
+        @connections << connection
+
+        @count += 1
+      end
+
+      def each(&block)
+        @connections.each(&block)
+      end
+
+      def broadcast(message)
+        Console.logger.info "Broadcast: #{message.inspect}"
+        start_time = Async::Clock.now
+
+        @connections.each do |connection|
+          @semaphore.async do
+            begin
+              connection.write(message)
+              connection.flush
+            rescue IOError
+              self.disconnect(connection)
+            end
+          end
+        end
+
+        end_time = Async::Clock.now
+        Console.logger.info "Duration: #{(end_time - start_time).round(3)}s for #{@connections.count} connected clients."
+      end
+
+      def disconnect connection
+        @connections.delete(connection)
+      end
+
       set :environment, MailCatcher.env
       set :prefix, MailCatcher.options[:http_path]
       set :asset_prefix, File.join(prefix, "assets")
@@ -61,21 +98,20 @@ module MailCatcher
       end
 
       get "/messages" do
-        if request.websocket?
-          request.websocket!(
-            :on_start => proc do |websocket|
-              bus_subscription = MailCatcher::Bus.subscribe do |message|
-                begin
-                  websocket.send_message(JSON.generate(message))
-                rescue => exception
-                  MailCatcher.log_exception("Error sending message through websocket", message, exception)
-                end
-              end
+        if Async::WebSocket::Adapters::Rack.websocket?(env)
+          puts 'WebSockets connection opened...'
+          Async::WebSocket::Adapters::Rack.open(env, protocols: %w[ws]) do |connection|
+            self.connect(connection)
 
-              websocket.on_close do |*|
-                MailCatcher::Bus.unsubscribe bus_subscription
+            begin
+              while message = connection.read
+                self.broadcast(message)
               end
-            end)
+            rescue Protocol::WebSocket::ClosedError, IOError
+              self.disconnect(connection)
+              connection.close
+            end
+          end
         else
           content_type :json
           JSON.generate(Mail.messages)

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,13 +32,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency 'async', '~> 1.25'
+  s.add_dependency 'async-http', '~> 0.56.3'
+  s.add_dependency 'async-io', '~> 1.32.1'
+  s.add_dependency 'async-websocket', '~> 0.19.0'
+  s.add_dependency 'falcon', '~> 0.39.1'
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.5.0"
-  s.add_dependency "skinny", "~> 0.2.3"
 
   s.add_development_dependency "coffee-script"
   s.add_development_dependency "compass", "~> 1.0.3"


### PR DESCRIPTION
Hi @sj26 
This PR is on behalf of Discourse.
This PR removes `Eventmachine` and replaces it with `Async`. It's not completed yet, will add some more changes to this.