### PR TITLE
Fix sqlite3 dependency constraint

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
-  s.add_dependency "sqlite3", "~> 1.3"
+  s.add_dependency "sqlite3", "~> 1.3", ">= 1.3.12"
   s.add_dependency "thin", "~> 1.5.0"
   s.add_dependency "skinny", "~> 0.2.3"
 


### PR DESCRIPTION
Fixes https://github.com/sj26/mailcatcher/issues/476

As of c887904ba2343e2fd0484a2876b242f02a0f9717 ([released in mailcatcher `v0.8.0`](https://github.com/sj26/mailcatcher/releases/tag/v0.8.0)), `MailCatcher::Mail#db` relies on `SQLite3::Database` responding to the `foreign_keys=` method:
https://github.com/sj26/mailcatcher/commit/c887904ba2343e2fd0484a2876b242f02a0f9717#diff-ba6f65d5c04d1ccc77ea172c1d1769c73d099580585d07dff7496e4401298e35R39
That method was introduced in:
https://github.com/sparklemotion/sqlite3-ruby/commit/ee010db02e7ba035984f3feb9b81ab2dacc768cd#diff-b01a6d9c63594012b75b704f2489342135f4f32924b02494d3236c8337c70167R264 (from https://github.com/sparklemotion/sqlite3-ruby/pull/136) which was released in sqlite3 `v1.3.12`.

However, mailcatcher's gemspec was previously declared to work with `sqlite3 ~> 1.3`, which includes `v1.3.0` to `v1.3.11`. This meant that using mailcatcher `v0.8.0` with one of those versions of sqlite3 would result in the following error:

<details>

<summary><code>NoMethodError - undefined method `foreign_keys=' for #<SQLite3::Database:0x00007fdba21f3d28>
Did you mean?  foreign_key_list:</code></summary>

```
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/mail.rb:39:in `block in db'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/mail.rb:11:in `tap'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/mail.rb:11:in `db'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/mail.rb:76:in `messages'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/web/application.rb:81:in `block in <class:Application>'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `block in compile!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (3 levels) in route!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:994:in `route_eval'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (2 levels) in route!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1015:in `block in process_route'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `catch'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `process_route'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:973:in `block in route!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `each'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `route!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1085:in `block in dispatch!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1082:in `dispatch!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `block in call!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `call!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:895:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/xss_header.rb:18:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/path_traversal.rb:16:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/json_csrf.rb:18:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-protection-1.5.5/lib/rack/protection/frame_options.rb:31:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/nulllogger.rb:9:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/head.rb:13:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:182:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:2013:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `block in call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1787:in `synchronize'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/urlmap.rb:66:in `block in call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/urlmap.rb:50:in `each'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/urlmap.rb:50:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/rack-1.6.13/lib/rack/builder.rb:153:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher/web.rb:26:in `call'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/thin-1.5.1/lib/thin/connection.rb:81:in `block in pre_process'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/thin-1.5.1/lib/thin/connection.rb:79:in `catch'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/thin-1.5.1/lib/thin/connection.rb:79:in `pre_process'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/thin-1.5.1/lib/thin/connection.rb:54:in `process'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/thin-1.5.1/lib/thin/connection.rb:39:in `receive_data'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run_machine'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/lib/mail_catcher.rb:180:in `run!'
	/Users/richard/.rvm/gems/ruby-2.6.6/gems/mailcatcher-0.8.0/bin/mailcatcher:6:in `<top (required)>'
	/Users/richard/.rvm/gems/ruby-2.6.6/bin/mailcatcher:23:in `load'
	/Users/richard/.rvm/gems/ruby-2.6.6/bin/mailcatcher:23:in `<main>'
	/Users/richard/.rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:24:in `eval'
	/Users/richard/.rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:24:in `<main>'
```

</details>

To fix this, we should explicitly require `sqlite3 >= 1.3.12`. That will force a compatible version of sqlite3 to be installed when mailcatcher is installed, and the compatible version will be used when mailcatcher is run.