### PR TITLE
Reduce Docker image weight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM ruby:2.7-alpine
+FROM alpine:latest
 MAINTAINER Samuel Cochran <sj26@sj26.com>
 
 ARG VERSION=0.8.0
 
-RUN apk add --no-cache build-base sqlite-libs sqlite-dev && \
-    gem install mailcatcher -v $VERSION && \
-    apk del --rdepends --purge build-base sqlite-dev
+RUN apk add --update ruby ruby-dev ruby-etc ruby-bigdecimal sqlite sqlite-dev build-base libstdc++ ca-certificates && \
+    gem install json --no-document  && \
+    gem install mailcatcher -v $VERSION --no-document && \
+    apk del --purge ruby-dev build-base && \
+    rm -rf /var/cache/apk/*
 
 EXPOSE 1025 1080
 


### PR DESCRIPTION
This repository now includes its own Docker image, so, there is no reason to keep my version (cf. https://hub.docker.com/repository/docker/jeanberu/mailcatcher). Since I built this image from `alpine`, it's a litte bit lighter (from 25Mo to 15Mo).