### PR TITLE
Bump Ruby & mailcatcher version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.0-alpine
 MAINTAINER Samuel Cochran <sj26@sj26.com>
 
-ARG VERSION=0.8.0
+ARG VERSION=0.8.1
 
 RUN apk add --no-cache build-base sqlite-libs sqlite-dev && \
     gem install mailcatcher -v $VERSION && \


### PR DESCRIPTION
This pull request just updates Ruby & mailcatcher version used in Docker image.

- `ruby:3.0-alpine` is available: https://hub.docker.com/layers/ruby/library/ruby/3.0-alpine/images/sha256-9b0267cc9f9eb190319727dadc5de472df54276241c192ed389f7fcd2e2db984?context=explore
- mailcatcher's latest version is v0.8.1: https://github.com/sj26/mailcatcher/releases/tag/v0.8.1