### PR TITLE
Correct the path for attachments by CID

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ if DEBUG:
 
 ### API
 
-A fairly RESTful URL schema means you can download a list of messages in JSON from `/messages`, each message's metadata with `/messages/:id.json`, and then the pertinent parts with `/messages/:id.html` and `/messages/:id.plain` for the default HTML and plain text version, `/messages/:id/:cid` for individual attachments by CID, or the whole message with `/messages/:id.source`.
+A fairly RESTful URL schema means you can download a list of messages in JSON from `/messages`, each message's metadata with `/messages/:id.json`, and then the pertinent parts with `/messages/:id.html` and `/messages/:id.plain` for the default HTML and plain text version, `/messages/:id/parts/:cid` for individual attachments by CID, or the whole message with `/messages/:id.source`.
 
 ## Caveats
 


### PR DESCRIPTION
As per commit a993c8c69b887ef225964f1e6f82e376a34869d9 the correct path includes `/parts/`