### PR TITLE
Support Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "eventmachine", "1.0.9.1"
   s.add_dependency "mail", "~> 2.3"
+  s.add_dependency "net-smtp"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"


### PR DESCRIPTION
Add ruby 3.1 to the ci workflow, and then add net-smtp to the gemspec because it is no longer include in stdlib.