### PR TITLE
Switch from Skinny to Faye Websocket

### DIFF
--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -4,14 +4,16 @@ require "pathname"
 require "net/http"
 require "uri"
 
+require "faye/websocket"
 require "sinatra"
-require "skinny"
 
 require "mail_catcher/bus"
 require "mail_catcher/mail"
 
+Faye::WebSocket.load_adapter("thin")
+
 class Sinatra::Request
-  include Skinny::Helpers
+  include Faye::WebSocket::Adapter
 end
 
 module MailCatcher
@@ -62,20 +64,24 @@ module MailCatcher
 
       get "/messages" do
         if request.websocket?
-          request.websocket!(
-            :on_start => proc do |websocket|
-              bus_subscription = MailCatcher::Bus.subscribe do |message|
-                begin
-                  websocket.send_message(JSON.generate(message))
-                rescue => exception
-                  MailCatcher.log_exception("Error sending message through websocket", message, exception)
-                end
-              end
+          bus_subscription = nil
 
-              websocket.on_close do |*|
-                MailCatcher::Bus.unsubscribe bus_subscription
+          ws = Faye::WebSocket.new(request.env)
+          ws.on(:open) do |_|
+            bus_subscription = MailCatcher::Bus.subscribe do |message|
+              begin
+                ws.send(JSON.generate(message))
+              rescue => exception
+                MailCatcher.log_exception("Error sending message through websocket", message, exception)
               end
-            end)
+            end
+          end
+
+          ws.on(:close) do |_|
+            MailCatcher::Bus.unsubscribe(bus_subscription) if bus_subscription
+          end
+
+          ws.rack_response
         else
           content_type :json
           JSON.generate(Mail.messages)

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -33,13 +33,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6.0"
 
   s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency "faye-websocket", "~> 0.11.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
   s.add_dependency "thin", "~> 1.5.0"
-  s.add_dependency "skinny", "~> 0.2.3"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"


### PR DESCRIPTION
Skinny has been blocking an upgrade to Thin for a while, so switch to faye-websocket.

Faye is also pretty rough — I had to hack Thin so that it stops websocket connections and doesn't hand on Ctrl+C, which was the only significant problem blocking merge of #496.