### PR TITLE
Show number of attachments on the message list

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -186,6 +186,7 @@ class MailCatcher
       .append($("<td/>").text(message.sender or "No sender").toggleClass("blank", !message.sender))
       .append($("<td/>").text((message.recipients || []).join(", ") or "No receipients").toggleClass("blank", !message.recipients.length))
       .append($("<td/>").text(message.subject or "No subject").toggleClass("blank", !message.subject))
+      .append($("<td/>").text(message.attachments_count))
       .append($("<td/>").text(@formatDate(message.created_at)))
       .prependTo($("#messages tbody"))
     @updateMessagesCount()

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -186,7 +186,7 @@ class MailCatcher
       .append($("<td/>").text(message.sender or "No sender").toggleClass("blank", !message.sender))
       .append($("<td/>").text((message.recipients || []).join(", ") or "No receipients").toggleClass("blank", !message.recipients.length))
       .append($("<td/>").text(message.subject or "No subject").toggleClass("blank", !message.subject))
-      .append($("<td/>").text(message.attachments_count || ""))
+      .append($("""<td class="attachments-count"/>""").text(message.attachments_count || ""))
       .append($("<td/>").text(@formatDate(message.created_at)))
       .prependTo($("#messages tbody"))
     @updateMessagesCount()

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -186,7 +186,7 @@ class MailCatcher
       .append($("<td/>").text(message.sender or "No sender").toggleClass("blank", !message.sender))
       .append($("<td/>").text((message.recipients || []).join(", ") or "No receipients").toggleClass("blank", !message.recipients.length))
       .append($("<td/>").text(message.subject or "No subject").toggleClass("blank", !message.subject))
-      .append($("<td/>").text(message.attachments_count))
+      .append($("<td/>").text(message.attachments_count || ""))
       .append($("<td/>").text(@formatDate(message.created_at)))
       .prependTo($("#messages tbody"))
     @updateMessagesCount()

--- a/assets/stylesheets/mailcatcher.css.sass
+++ b/assets/stylesheets/mailcatcher.css.sass
@@ -126,6 +126,7 @@ body > header
         &.attachments-header
           width: 3em
           text-align: right
+          padding-right: 1em
     tbody tr
       cursor: pointer
       +transition(0.1s ease)
@@ -144,6 +145,7 @@ body > header
           font-style: italic
         &.attachments-count
           text-align: right
+          padding-right: 1em
 #resizer
   padding-bottom: 5px
   cursor: ns-resize

--- a/assets/stylesheets/mailcatcher.css.sass
+++ b/assets/stylesheets/mailcatcher.css.sass
@@ -123,6 +123,8 @@ body > header
         font-weight: bold
         color: #666
         +text-shadow(0 1px 0 white)
+        &.attachments-header
+          width: 3em
     tbody tr
       cursor: pointer
       +transition(0.1s ease)

--- a/assets/stylesheets/mailcatcher.css.sass
+++ b/assets/stylesheets/mailcatcher.css.sass
@@ -125,6 +125,7 @@ body > header
         +text-shadow(0 1px 0 white)
         &.attachments-header
           width: 3em
+          text-align: right
     tbody tr
       cursor: pointer
       +transition(0.1s ease)
@@ -141,6 +142,8 @@ body > header
         &.blank
           color: #666
           font-style: italic
+        &.attachments-count
+          text-align: right
 #resizer
   padding-bottom: 5px
   cursor: ns-resize

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -56,9 +56,11 @@ module MailCatcher::Mail extend self
       add_message_part(message_id, cid, part.mime_type || "text/plain", part.attachment? ? 1 : 0, part.filename, part.charset, body, body.length)
     end
 
+    attachments_count = parts.count(&:attachment?)
+
     EventMachine.next_tick do
       message = MailCatcher::Mail.message message_id
-      MailCatcher::Bus.push(type: "add", message: message)
+      MailCatcher::Bus.push(type: "add", message: message.merge("attachments_count" => attachments_count))
     end
   end
 

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -75,7 +75,7 @@ module MailCatcher::Mail extend self
   end
 
   def messages
-    @messages_query ||= db.prepare "SELECT id, sender, recipients, subject, size, created_at FROM message ORDER BY created_at, id ASC"
+    @messages_query ||= db.prepare "SELECT id, sender, recipients, subject, size, created_at, (SELECT COUNT(*) FROM message_part WHERE message_id = message.id AND is_attachment = 1) AS attachments_count FROM message ORDER BY created_at, id ASC"
     @messages_query.execute.map do |row|
       Hash[row.fields.zip(row)].tap do |message|
         message["recipients"] &&= JSON.parse(message["recipients"])

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -23,8 +23,12 @@ RSpec.describe MailCatcher, type: :feature do
     message_row_element.find(:xpath, ".//td[3]")
   end
 
-  def message_received_element
+  def message_attachments_element
     message_row_element.find(:xpath, ".//td[4]")
+  end
+
+  def message_received_element
+    message_row_element.find(:xpath, ".//td[5]")
   end
 
   def html_tab_element
@@ -227,6 +231,7 @@ RSpec.describe MailCatcher, type: :feature do
     expect(message_from_element).to have_text(DEFAULT_FROM)
     expect(message_to_element).to have_text(DEFAULT_TO)
     expect(message_subject_element).to have_text("Test Attachment Mail")
+    expect(message_attachments_element.text).to eq("1")
     expect(Time.parse(message_received_element.text)).to be <= Time.now + 5
 
     message_row_element.click

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -262,6 +262,11 @@ RSpec.describe MailCatcher, type: :feature do
       expect(page).to have_text "Content-Disposition: attachment"
       # Too hard to add expectations on the transfer encoded attachment contents
     end
+
+    # Refresh the page
+    refresh
+
+    expect(message_attachments_element.text).to eq("1")
   end
 
   it "doesn't choke on messages containing dots" do

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe MailCatcher, type: :feature do
     expect(message_from_element).to have_text(DEFAULT_FROM)
     expect(message_to_element).to have_text(DEFAULT_TO)
     expect(message_subject_element).to have_text("Plain mail")
+    expect(message_attachments_element.text).to eq("")
     expect(Time.parse(message_received_element.text)).to be <= Time.now + 5
 
     message_row_element.click

--- a/views/index.erb
+++ b/views/index.erb
@@ -34,7 +34,7 @@
           <th>From</th>
           <th>To</th>
           <th>Subject</th>
-          <th>📎</th>
+          <th class="attachments-header">📎</th>
           <th>Received</th>
         </tr>
       </thead>

--- a/views/index.erb
+++ b/views/index.erb
@@ -34,6 +34,7 @@
           <th>From</th>
           <th>To</th>
           <th>Subject</th>
+          <th></th>
           <th>Received</th>
         </tr>
       </thead>

--- a/views/index.erb
+++ b/views/index.erb
@@ -34,7 +34,7 @@
           <th>From</th>
           <th>To</th>
           <th>Subject</th>
-          <th></th>
+          <th>📎</th>
           <th>Received</th>
         </tr>
       </thead>


### PR DESCRIPTION
These changes bring the number of attachments for each message on the message list.

This is how it looks after these changes:

<img width="603" alt="number-of-attachments-shown" src="https://user-images.githubusercontent.com/610423/201547654-fb9d4f31-1471-43ed-a5c8-b68c3a8313e6.png">
