### PR TITLE
Add HTML source view tab

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -302,10 +302,10 @@ class MailCatcher
 
   escape_html_reserved_characters: (text) ->
     text
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll("\"", "&quot;")
 
   refresh: ->
     $.getJSON "messages", (messages) =>

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -286,27 +286,26 @@ class MailCatcher
         message_iframe = $("#message iframe").contents()
         text = message_iframe.text()
 
-        # Escape special characters
-        text = text.replace(/&/g, "&amp;")
-        text = text.replace(/</g, "&lt;")
-        text = text.replace(/>/g, "&gt;")
-        text = text.replace(/"/g, "&quot;")
+        text = @escape_html_reserved_characters text
 
         message_iframe.find("html").html("<body><pre>#{text}</pre></body>")
       when "plain"
         message_iframe = $("#message iframe").contents()
         text = message_iframe.text()
 
-        # Escape special characters
-        text = text.replace(/&/g, "&amp;")
-        text = text.replace(/</g, "&lt;")
-        text = text.replace(/>/g, "&gt;")
-        text = text.replace(/"/g, "&quot;")
+        text = @escape_html_reserved_characters text
 
         # Autolink text
         text = text.replace(/((http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?)/g, """<a href="$1" target="_blank">$1</a>""")
 
         message_iframe.find("html").html("""<body style="font-family: sans-serif; white-space: pre-wrap">#{text}</body>""")
+
+  escape_html_reserved_characters: (text) ->
+    text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
 
   refresh: ->
     $.getJSON "messages", (messages) =>

--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -282,6 +282,17 @@ class MailCatcher
       when "html"
         body = $("#message iframe").contents().find("body")
         $("a", body).attr("target", "_blank")
+      when "html-source"
+        message_iframe = $("#message iframe").contents()
+        text = message_iframe.text()
+
+        # Escape special characters
+        text = text.replace(/&/g, "&amp;")
+        text = text.replace(/</g, "&lt;")
+        text = text.replace(/>/g, "&gt;")
+        text = text.replace(/"/g, "&quot;")
+
+        message_iframe.find("html").html("<body><pre>#{text}</pre></body>")
       when "plain"
         message_iframe = $("#message iframe").contents()
         text = message_iframe.text()

--- a/lib/mail_catcher/web/application.rb
+++ b/lib/mail_catcher/web/application.rb
@@ -116,6 +116,7 @@ module MailCatcher
             "formats" => [
               "source",
               ("html" if Mail.message_has_html? id),
+              ("html-source" if Mail.message_has_html? id),
               ("plain" if Mail.message_has_plain? id)
             ].compact,
             "attachments" => Mail.message_attachments(id),
@@ -136,6 +137,16 @@ module MailCatcher
           body.gsub! /cid:([^'"> ]+)/, "#{id}/parts/\\1"
 
           body
+        else
+          not_found
+        end
+      end
+
+      get "/messages/:id.html-source" do
+        id = params[:id].to_i
+        if part = Mail.message_part_html(id)
+          content_type "text/plain", :charset => (part["charset"] || "utf8")
+          part["body"]
         else
           not_found
         end

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe MailCatcher, type: :feature do
     page.find("#message header .format.html a")
   end
 
+  def html_source_tab_element
+    page.find("#message header .format.html-source a")
+  end
+
   def plain_tab_element
     page.find("#message header .format.plain a")
   end
@@ -120,6 +124,28 @@ RSpec.describe MailCatcher, type: :feature do
       expect(page).to have_no_text("Yo, you slimey scoundrel.")
       expect(page).to have_text("Content-Type: text/html")
       expect(page).to have_text("Yo, you <em>slimey scoundrel</em>.")
+    end
+  end
+
+  it "catches and displays an html message as html source" do
+    deliver_example("htmlmail")
+
+    # Do not reload, make sure that the message appears via websockets
+
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Test HTML Mail")
+
+    message_row_element.click
+
+    expect(html_tab_element).to be_visible
+    expect(html_source_tab_element).to be_visible
+
+    html_source_tab_element.click
+
+    # Load the HTML mail but discard the headers
+    html_source = read_example("htmlmail").split("\n\n", 2).last.chomp
+
+    within_frame do
+      expect(page.text).to eq(html_source)
     end
   end
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -58,6 +58,7 @@
       <nav class="views">
         <ul>
           <li class="format tab html selected" data-message-format="html"><a href="#">HTML</a></li>
+          <li class="format tab html-source" data-message-format="html-source"><a href="#">HTML Source</a></li>
           <li class="format tab plain" data-message-format="plain"><a href="#">Plain Text</a></li>
           <li class="format tab source" data-message-format="source"><a href="#">Source</a></li>
           <li class="action download" data-message-format="html"><a href="#" class="button"><span>Download</span></a></li>


### PR DESCRIPTION
I added an HTML source view because I needed to look at the HTML sources and it was so much faster to use this than the browser's developer tools.

For an email with an HTML part such as this:

<img width="720" alt="message-html" src="https://user-images.githubusercontent.com/610423/202898106-c4652e8c-9614-48dd-919e-df81ebb5d8df.png">

the HTML source view would look like this:

<img width="720" alt="message-html-source" src="https://user-images.githubusercontent.com/610423/202898135-0ec9a312-c530-486f-87d7-2fe129deed5b.png">

I noticed someone had already requested this a couple of years ago, too.

Resolves #432.