### PR TITLE
Update thin version

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack", "~> 1.5"
   s.add_dependency "sinatra", "~> 1.2"
   s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.5.0"
+  s.add_dependency "thin", "~> 1.8"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"


### PR DESCRIPTION
Version 1.5.x no longer works on Ruby 3.2:

```
/home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/thin-1.5.1/lib/thin/server.rb:104:in `block in initialize': uninitialized constant Thin::Server::Fixnum (NameError)
17:11:39 mail.1            | 
17:11:39 mail.1            |         when Fixnum, /^\d+$/ then port    = arg.to_i
17:11:39 mail.1            |              ^^^^^^
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/thin-1.5.1/lib/thin/server.rb:102:in `each'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/thin-1.5.1/lib/thin/server.rb:102:in `initialize'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/thin-1.5.1/lib/thin/server.rb:145:in `new'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/thin-1.5.1/lib/thin/server.rb:145:in `start'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/mailcatcher-0.8.2/lib/mail_catcher.rb:190:in `block (2 levels) in run!'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/mailcatcher-0.8.2/lib/mail_catcher.rb:233:in `rescue_port'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/mailcatcher-0.8.2/lib/mail_catcher.rb:189:in `block in run!'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run_machine'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/mailcatcher-0.8.2/lib/mail_catcher.rb:180:in `run!'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/mailcatcher-0.8.2/bin/mailcatcher:6:in `<top (required)>'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/bin/mailcatcher:25:in `load'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/bin/mailcatcher:25:in `<main>'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/bin/ruby_executable_hooks:22:in `eval'
17:11:39 mail.1            | 	from /home/fletch/.asdf/installs/ruby/3.2.0/bin/ruby_executable_hooks:22:in `<main>'
```