### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,17 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
 
     - uses: browser-actions/setup-chrome@latest
     - uses: nanasess/setup-chromedriver@master
@@ -32,7 +32,7 @@ jobs:
       run: bundle exec rake test
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: test-artifacts


### PR DESCRIPTION
Adds Ruby 3.2 to the CI matrix.  Also updates the CI actions to v3, eliminating Node 12 warning.