### PR TITLE
gemspec - eventmachine, rack, sinatra, sqlite3

### DIFF
--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -32,13 +32,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6.0"
 
-  s.add_dependency "eventmachine", "1.0.9.1"
+  s.add_dependency "eventmachine", "1.2.7"
   s.add_dependency "faye-websocket", "~> 0.11.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
-  s.add_dependency "rack", "~> 1.5"
-  s.add_dependency "sinatra", "~> 1.2"
-  s.add_dependency "sqlite3", "~> 1.3"
+  s.add_dependency "rack", "~> 2.2"
+  s.add_dependency "sinatra", "~> 2.2"
+  s.add_dependency "sqlite3", "~> 1.6"
   s.add_dependency "thin", "~> 1.8"
 
   s.add_development_dependency "capybara"


### PR DESCRIPTION
I am not familiar with mailcatcher.  In another repo, someone opened an [issue](https://github.com/oneclick/rubyinstaller2/issues/347) about installing on Windows, and I took a look at the gemspec.

Some of the dependencies are locked to old versions, and with EventMachine, that's an issue.

So, I updated a few items, and ran CI.  It passed in my fork, so I'll assume it passes here.  EventMachine may have some issues with OpenSSL 3, not sure about thin.

Also, re Windows, the current EventMachine release includes a Windows pre-compiled gem, but its gemspec does not have a `required_ruby_version` properly set with an upper bound.  It only includes extension files for Ruby 2.0 thru 2.3.  It's also rather old...