### PR TITLE
Fix typos

### DIFF
--- a/assets/javascripts/mailcatcher.js.coffee
+++ b/assets/javascripts/mailcatcher.js.coffee
@@ -184,7 +184,7 @@ class MailCatcher
   addMessage: (message) ->
     $("<tr />").attr("data-message-id", message.id.toString())
       .append($("<td/>").text(message.sender or "No sender").toggleClass("blank", !message.sender))
-      .append($("<td/>").text((message.recipients || []).join(", ") or "No receipients").toggleClass("blank", !message.recipients.length))
+      .append($("<td/>").text((message.recipients || []).join(", ") or "No recipients").toggleClass("blank", !message.recipients.length))
       .append($("<td/>").text(message.subject or "No subject").toggleClass("blank", !message.subject))
       .append($("<td/>").text(@formatDate(message.created_at)))
       .prependTo($("#messages tbody"))

--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -41,7 +41,7 @@ module MailCatcher extend self
     RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
   end
 
-  def browseable?
+  def browsable?
     windows? or which? "open"
   end
 
@@ -134,7 +134,7 @@ module MailCatcher extend self
           end
         end
 
-        if browseable?
+        if browsable?
           parser.on("-b", "--browse", "Open web browser") do
             options[:browse] = true
           end
@@ -197,7 +197,7 @@ module MailCatcher extend self
         trap(signal) { EM.add_timer(0) { quit! } }
       end
 
-      # Open the web browser before detatching console
+      # Open the web browser before detaching console
       if options[:browse]
         EventMachine.next_tick do
           browse http_url


### PR DESCRIPTION
Found misspellings with `typos`.

There are a few more in `vendor/` - left those untouched 🛑

[_more way to find bugs_](https://github.com/szepeviktor/byte-level-care/tree/master/.github/workflows)
