### PR TITLE
Drop legacy Ruby versions, including 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request: 
+  pull_request:
     branches: [ main ]
   workflow_dispatch: ~
 
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -3,20 +3,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# mime-types 3+, required by mail, requires ruby 2.0+
-gem "mime-types", "< 3" if RUBY_VERSION < "2"
-
-if RUBY_VERSION < "2.7"
-  # Ruby 2.7 requirement introduced
-  # https://github.com/SeleniumHQ/selenium/blob/selenium-4.2.0/rb/CHANGES#L25
-  gem "selenium-webdriver", "< 4.2.0", group: :development
-elsif RUBY_VERSION < "2.8"
-  # Ruby 3.0 requirement introduced
-  # https://github.com/SeleniumHQ/selenium/blob/selenium-4.9.1/rb/CHANGES#L5
-  gem "selenium-webdriver", "< 4.9.1", group: :development
-end
-
-#group :development do
-#  gem "pry"
-#end

--- a/lib/mail_catcher/version.rb
+++ b/lib/mail_catcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailCatcher
-  VERSION = "0.9.1.beta2"
+  VERSION = "0.10.0.alpha1"
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -30,14 +30,14 @@ Gem::Specification.new do |s|
   s.executables = ["mailcatcher", "catchmail"]
   s.extra_rdoc_files = ["README.md", "LICENSE"]
 
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency "eventmachine", "~> 1.0"
   s.add_dependency "faye-websocket", "~> 0.11.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
-  s.add_dependency "rack", "~> 1.5"
-  s.add_dependency "sinatra", "~> 1.2"
+  s.add_dependency "rack", "~> 2.2"
+  s.add_dependency "sinatra", "~> 3.2"
   s.add_dependency "sqlite3", "~> 1.3"
   s.add_dependency "thin", "~> 1.8"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,16 +21,20 @@ HTTP_PORT = 20080
 # Use headless chrome by default
 Capybara.default_driver = :selenium
 Capybara.register_driver :selenium do |app|
-  args = %w[--disable-gpu --force-device-scale-factor=1 --window-size=1400,900]
+  opts = Selenium::WebDriver::Chrome::Options.new
+
+  opts.add_argument('disable-gpu')
+  opts.add_argument('force-device-scale-factor=1')
+  opts.add_argument('window-size=1400,900')
 
   # Use NO_HEADLESS to open real chrome when debugging tests
   unless ENV["NO_HEADLESS"]
-    args << "--headless"
+    opts.add_argument('headless=new')
   end
 
   Capybara::Selenium::Driver.new app, browser: :chrome,
-    service: Selenium::WebDriver::Service.chrome(args: { log_path: File.expand_path("../tmp/chromedriver.log", __dir__) }),
-    options: Selenium::WebDriver::Chrome::Options.new(args: args)
+    service: Selenium::WebDriver::Service.chrome(log: File.expand_path("../tmp/chromedriver.log", __dir__)),
+    options: opts
 end
 
 Capybara.configure do |config|


### PR DESCRIPTION
3.0 will EOL soon, and it has issues when compiling eventmachine

Also:

- Fix compatibility with latest Selenium
- Bump Sinatra and Rack dependency to allow Ruby 3.3

Close #553