### PR TITLE
Fix `docker run` port publishing options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ if DEBUG:
 There is a Docker image available [on Docker Hub](https://hub.docker.com/r/sj26/mailcatcher):
 
 ```
-$ docker run -p 1080 -p 1025 sj26/mailcatcher
+$ docker run -p 1080:1080 -p 1025:1025 sj26/mailcatcher
 Unable to find image 'sj26/mailcatcher:latest' locally
 latest: Pulling from sj26/mailcatcher
 8c6d1654570f: Already exists


### PR DESCRIPTION
`-p N` publishes `N` port from container to ephemeral port on the host machine (chosen by Docker), to publish container port to the same port on the host `-p N:N` syntax should be used.

See https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/