### PR TITLE
Upgrade dependencies for Ruby 3.4 and Rack 3 compatibility (v0.11.0)

### DIFF
--- a/lib/mail_catcher/version.rb
+++ b/lib/mail_catcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailCatcher
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -30,16 +30,16 @@ Gem::Specification.new do |s|
   s.executables = ["mailcatcher", "catchmail"]
   s.extra_rdoc_files = ["README.md", "LICENSE"]
 
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = ">= 3.4"
 
-  s.add_dependency "eventmachine", "~> 1.0"
-  s.add_dependency "faye-websocket", "~> 0.11.1"
-  s.add_dependency "mail", "~> 2.3"
+  s.add_dependency "eventmachine", "~> 1.2.7"
+  s.add_dependency "faye-websocket", "~> 0.12.0"
+  s.add_dependency "mail", "~> 2.9"
   s.add_dependency "net-smtp"
-  s.add_dependency "rack", "~> 2.2"
-  s.add_dependency "sinatra", "~> 3.2"
-  s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.8"
+  s.add_dependency "rack", "~> 3.2.4"
+  s.add_dependency "sinatra", "~> 4.2.1"
+  s.add_dependency "sqlite3", "~> 2.9"
+  s.add_dependency "thin", "~> 2.0"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"
@@ -48,10 +48,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"
-  s.add_development_dependency "sass"
+  s.add_development_dependency "sass-embedded", "~> 1.0"
   s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "sprockets"
-  s.add_development_dependency "sprockets-sass"
+  s.add_development_dependency "sprockets-sass_embedded"
   s.add_development_dependency "sprockets-helpers"
   s.add_development_dependency "uglifier"
 end


### PR DESCRIPTION
## Upgrade dependencies for Ruby 3.4 and Rack 3 compatibility
This PR brings MailCatcher up to date with modern Ruby and Rack standards, resolving compilation and compatibility issues with recent gem versions.
### key Changes
*   **Ruby Version**: Bumped requirement to `>= 3.4`.
*   **Rack 3 Compatibility**:
    *   Upgraded `rack` to `~> 3.2.4`.
    *   Upgraded `sinatra` to `~> 4.2.1`.
    *   Upgraded `thin` to `~> 2.0` (resolves Rack 3 conflict).
*   **Sass Migration**:
    *   Replaced the deprecated `sass` and `sprockets-sass` dependencies (which are incompatible with Rack 3) with `sass-embedded` and `sprockets-sass_embedded`.
*   **General Dependency Updates**:
    *   `sqlite3` ~> 2.9
    *   `mail` ~> 2.9
    *   `eventmachine` ~> 1.2.7
    *   `faye-websocket` ~> 0.12.0
*   **Version Bump**: Updated project version to `0.11.0`.