### PR TITLE
Update vulnerable web dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,14 @@ task "assets" do
   sprockets = MailCatcher::Web::Assets
   sprockets.css_compressor = :sass
   sprockets.js_compressor = :uglifier
-  sprockets.each_logical_path(/(\Amailcatcher\.(js|css)|\.(xsl|png)\Z)/) do |logical_path|
+  logical_paths = %w[
+    mailcatcher.js
+    mailcatcher.css
+    logo.png
+    logo_2x.png
+    logo_large.png
+  ]
+  logical_paths.each do |logical_path|
     if asset = sprockets.find_asset(logical_path)
       target = File.join(compiled_path, logical_path)
       asset.write_to target

--- a/lib/mail_catcher/web.rb
+++ b/lib/mail_catcher/web.rb
@@ -18,7 +18,7 @@ module MailCatcher
         end
 
         # This should only affect when http_path is anything but "/" above
-        run lambda { |env| [302, {"Location" => MailCatcher.options[:http_path]}, []] }
+        run lambda { |env| [302, {"location" => MailCatcher.options[:http_path]}, []] }
       end
     end
 

--- a/lib/mail_catcher/web/assets.rb
+++ b/lib/mail_catcher/web/assets.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "sprockets"
-require "sprockets-sass"
 require "compass"
 
 module MailCatcher
@@ -10,6 +9,14 @@ module MailCatcher
       Dir["#{sprockets.root}/{,vendor}/assets/*"].each do |path|
         sprockets.append_path(path)
       end
+      Compass.configuration.sass_load_paths.each do |path|
+        sprockets.append_path(path.root) if path.respond_to?(:root)
+      end
+      sprockets.register_transformer "text/sass", "text/css", Sprockets::SassCompressor.new(
+        :syntax => :sass,
+        :style => :expanded,
+        :load_paths => sprockets.paths,
+      )
     end
   end
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |s|
   s.add_dependency "faye-websocket", "~> 0.11.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
-  s.add_dependency "rack", "~> 2.2"
-  s.add_dependency "sinatra", "~> 3.2"
+  s.add_dependency "rack", "~> 3.2"
+  s.add_dependency "sinatra", "~> 4.2"
   s.add_dependency "sqlite3", "~> 1.3"
-  s.add_dependency "thin", "~> 1.8"
+  s.add_dependency "thin", "~> 2.0"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -33,13 +33,14 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "eventmachine", "~> 1.0"
-  s.add_dependency "faye-websocket", "~> 0.11.1"
+  s.add_dependency "faye-websocket", "~> 0.12.0"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
   s.add_dependency "rack", "~> 3.2", ">= 3.2.6"
   s.add_dependency "sinatra", "~> 4.2", ">= 4.2.1"
   s.add_dependency "sqlite3", "~> 2.0"
   s.add_dependency "thin", "~> 2.0"
+  s.add_dependency "websocket-driver", "~> 0.8.2"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -51,8 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency "sass"
   s.add_development_dependency "selenium-webdriver"
-  s.add_development_dependency "sprockets"
-  s.add_development_dependency "sprockets-sass"
+  s.add_development_dependency "sprockets", "~> 4.4"
   s.add_development_dependency "sprockets-helpers"
   s.add_development_dependency "uglifier"
 end

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |s|
   s.add_dependency "faye-websocket", "~> 0.11.1"
   s.add_dependency "mail", "~> 2.3"
   s.add_dependency "net-smtp"
-  s.add_dependency "rack", "~> 2.2"
-  s.add_dependency "sinatra", "~> 3.2"
+  s.add_dependency "rack", "~> 3.2", ">= 3.2.6"
+  s.add_dependency "sinatra", "~> 4.2", ">= 4.2.1"
   s.add_dependency "sqlite3", "~> 2.0"
-  s.add_dependency "thin", "~> 1.8"
+  s.add_dependency "thin", "~> 2.0"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"


### PR DESCRIPTION
## Why

MailCatcher's current Rack, Sinatra, Thin, and WebSocket dependency lines resolve releases with known security advisories. The original three version bumps are not sufficient on their own: `sprockets-sass` pins Sprockets 3 and Rack below 3, while Faye 0.11 resolves a vulnerable `websocket-driver`.

## What

- Migrate asset compilation to Sprockets 4 while preserving the existing Compass/Sass output.
- Require Rack 3.2.6+, Sinatra 4.2.1+, and Thin 2, including Rack 3-compliant redirect headers.
- Require Faye WebSocket 0.12 and `websocket-driver` 0.8.2+.

## Validation

- Full suite: 30 examples, 0 failures on Ruby 3.3.12, 3.4.10, and 4.0.6, plus the minimum permitted gem versions.
- Live SMTP-to-WebSocket UI behavior passed in Chromium, Firefox, and WebKit, including message arrival, HTML/source rendering, keyboard deletion, and API state, with no browser errors.
- Compiled CSS and JavaScript are byte-identical to the previous asset pipeline.
- An isolated built-gem install passed CLI, SMTP, HTTP API, packaged asset, and shutdown smoke tests.
- RubySec reports no vulnerabilities.

Docker was not available in the test orb. Native Safari was not available; Playwright WebKit was tested instead. Each commit records the evidence specific to its change.