### PR TITLE
Modernize GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,9 @@ jobs:
       with:
         node-version: 24
 
-    - uses: browser-actions/setup-chrome@v2.2.0
-      id: chrome
-      with:
-        install-chromedriver: true
-
     - name: Run tests
       run: bundle exec rake test
       timeout-minutes: 5
-      env:
-        CHROME_BIN: ${{ steps.chrome.outputs.chrome-path }}
-        CHROMEDRIVER_BIN: ${{ steps.chrome.outputs.chromedriver-path }}
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch: ~
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -18,25 +21,28 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
 
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v7.0.0
+      with:
+        node-version: 24
 
-    - uses: browser-actions/setup-chrome@latest
-    - uses: nanasess/setup-chromedriver@master
+    - uses: browser-actions/setup-chrome@v2.2.0
+      with:
+        install-chromedriver: true
 
     - name: Run tests
       run: bundle exec rake test
       timeout-minutes: 5
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7.0.1
       if: always()
       with:
-        name: test-artifacts
+        name: test-artifacts-${{ matrix.os }}-ruby-${{ matrix.ruby-version }}
         path: tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,16 @@ jobs:
         node-version: 24
 
     - uses: browser-actions/setup-chrome@v2.2.0
+      id: chrome
       with:
         install-chromedriver: true
 
     - name: Run tests
       run: bundle exec rake test
       timeout-minutes: 5
+      env:
+        CHROME_BIN: ${{ steps.chrome.outputs.chrome-path }}
+        CHROMEDRIVER_BIN: ${{ steps.chrome.outputs.chromedriver-path }}
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v7.0.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ HTTP_PORT = 20080
 Capybara.default_driver = :selenium
 Capybara.register_driver :selenium do |app|
   opts = Selenium::WebDriver::Chrome::Options.new
-  opts.binary = ENV["CHROME_BIN"] if ENV["CHROME_BIN"]
 
   opts.add_argument('disable-gpu')
   opts.add_argument('force-device-scale-factor=1')
@@ -33,11 +32,8 @@ Capybara.register_driver :selenium do |app|
     opts.add_argument('headless=new')
   end
 
-  service_options = {log: File.expand_path("../tmp/chromedriver.log", __dir__)}
-  service_options[:path] = ENV["CHROMEDRIVER_BIN"] if ENV["CHROMEDRIVER_BIN"]
-
   Capybara::Selenium::Driver.new app, browser: :chrome,
-    service: Selenium::WebDriver::Service.chrome(**service_options),
+    service: Selenium::WebDriver::Service.chrome(log: File.expand_path("../tmp/chromedriver.log", __dir__)),
     options: opts
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ HTTP_PORT = 20080
 Capybara.default_driver = :selenium
 Capybara.register_driver :selenium do |app|
   opts = Selenium::WebDriver::Chrome::Options.new
+  opts.binary = ENV["CHROME_BIN"] if ENV["CHROME_BIN"]
 
   opts.add_argument('disable-gpu')
   opts.add_argument('force-device-scale-factor=1')
@@ -32,8 +33,11 @@ Capybara.register_driver :selenium do |app|
     opts.add_argument('headless=new')
   end
 
+  service_options = {log: File.expand_path("../tmp/chromedriver.log", __dir__)}
+  service_options[:path] = ENV["CHROMEDRIVER_BIN"] if ENV["CHROMEDRIVER_BIN"]
+
   Capybara::Selenium::Driver.new app, browser: :chrome,
-    service: Selenium::WebDriver::Service.chrome(log: File.expand_path("../tmp/chromedriver.log", __dir__)),
+    service: Selenium::WebDriver::Service.chrome(**service_options),
     options: opts
 end
 


### PR DESCRIPTION
## Why

The CI workflow uses retired action releases and mutable browser installer references.

## What

Update the workflow to current explicit action releases, rely on the matched browser tooling already provided by GitHub-hosted runners, scope the workflow token to read-only repository access, and give matrix artifacts unique names. Keep the supported Ruby matrix unchanged at 3.1–3.3.

Follows #581, which added the Amp orb setup.