### PR TITLE
Expand end-to-end coverage of user-facing behavior

### DIFF
--- a/bin/catchmail
+++ b/bin/catchmail
@@ -47,7 +47,7 @@ OptionParser.new do |parser|
 
   parser.on('-h', '--help', 'Display this help information') do
     puts parser
-    exit!
+    exit
   end
 end.parse!
 

--- a/examples/inlinemail
+++ b/examples/inlinemail
@@ -1,0 +1,20 @@
+To: Blah <blah@blah.com>
+From: Me <me@sj26.com>
+Subject: Inline image
+Mime-Version: 1.0
+Content-Type: multipart/related; boundary=INLINE-BOUNDARY
+
+--INLINE-BOUNDARY
+Content-Type: text/html; charset=UTF-8
+
+<html><body><p>Embedded below:</p><img src="cid:inline-image@example.com" alt="A tiny image"></body></html>
+
+--INLINE-BOUNDARY
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+Content-Disposition: inline; filename="pixel.png"
+Content-ID: <inline-image@example.com>
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+
+--INLINE-BOUNDARY--

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -173,7 +173,7 @@ module MailCatcher::Mail extend self
 
   def delete_older_messages!(count = MailCatcher.options[:messages_limit])
     return if count.nil?
-    @older_messages_query ||= db.prepare "SELECT id FROM message WHERE id NOT IN (SELECT id FROM message ORDER BY created_at DESC LIMIT ?)"
+    @older_messages_query ||= db.prepare "SELECT id FROM message WHERE id NOT IN (SELECT id FROM message ORDER BY created_at DESC, id DESC LIMIT ?)"
     @older_messages_query.execute(count).map do |row|
       Hash[row.fields.zip(row)]
     end.each do |message|

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "HTTP API", type: :feature, browser: false do
+  def json_response(path)
+    response = http_request(:get, path)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(response["Content-Type"]).to start_with("application/json")
+    JSON.parse(response.body)
+  end
+
+  it "serves the message list, metadata, bodies, attachments, and original email" do
+    deliver_example("multipartmail")
+    deliver_example("attachmail")
+
+    messages = json_response("/messages")
+    expect(messages.map { |message| message["subject"] }).to contain_exactly(
+      "Test Multipart Mail",
+      "Test Attachment Mail",
+    )
+
+    multipart_id = messages.find { |message| message["subject"] == "Test Multipart Mail" }.fetch("id")
+    attachment_id = messages.find { |message| message["subject"] == "Test Attachment Mail" }.fetch("id")
+    multipart = json_response("/messages/#{multipart_id}.json")
+
+    expect(multipart).to include(
+      "id" => multipart_id,
+      "sender" => "<#{DEFAULT_FROM}>",
+      "recipients" => ["<#{DEFAULT_TO}>"],
+      "subject" => "Test Multipart Mail",
+      "attachments" => [],
+    )
+    expect(multipart.fetch("formats")).to contain_exactly("source", "html", "plain")
+
+    plain = http_request(:get, "/messages/#{multipart_id}.plain")
+    expect(plain).to be_a(Net::HTTPOK)
+    expect(plain["Content-Type"]).to start_with("text/plain")
+    expect(plain.body).to include("Plain text mail")
+
+    html = http_request(:get, "/messages/#{multipart_id}.html")
+    expect(html).to be_a(Net::HTTPOK)
+    expect(html["Content-Type"]).to start_with("text/html")
+    expect(html.body).to include("<em>HTML</em> mail")
+
+    source = http_request(:get, "/messages/#{multipart_id}.source")
+    expect(source).to be_a(Net::HTTPOK)
+    expect(source["Content-Type"]).to start_with("text/plain")
+    expect(source.body).to include("Subject: Test Multipart Mail")
+
+    original = http_request(:get, "/messages/#{multipart_id}.eml")
+    expect(original).to be_a(Net::HTTPOK)
+    expect(original["Content-Type"]).to start_with("message/rfc822")
+    expect(original.body).to eq(source.body)
+
+    attachment = json_response("/messages/#{attachment_id}.json").fetch("attachments").fetch(0)
+    part = http_request(:get, "/messages/#{attachment_id}/parts/#{attachment.fetch("cid")}")
+    expect(part).to be_a(Net::HTTPOK)
+    expect(part["Content-Type"]).to start_with("text/plain")
+    expect(part["Content-Disposition"]).to match(%r{\Aattachment; filename="?attachment"?\z})
+    expect(part.body).to eq("Hello, I am an attachment!\r\n")
+  end
+
+  it "deletes individual messages and the entire inbox" do
+    deliver_example("plainmail")
+    deliver_example("htmlmail")
+
+    message_ids = json_response("/messages").map { |message| message.fetch("id") }
+
+    response = http_request(:delete, "/messages/#{message_ids.first}")
+    expect(response).to be_a(Net::HTTPNoContent)
+    expect(json_response("/messages").map { |message| message["id"] }).to eq([message_ids.last])
+
+    response = http_request(:delete, "/messages")
+    expect(response).to be_a(Net::HTTPNoContent)
+    expect(json_response("/messages")).to be_empty
+  end
+
+  it "returns a useful not-found page for missing messages and formats" do
+    deliver_example("plainmail")
+    message_id = json_response("/messages").fetch(0).fetch("id")
+
+    [
+      "/messages/999.json",
+      "/messages/#{message_id}.html",
+      "/messages/#{message_id}/parts/missing",
+    ].each do |path|
+      response = http_request(:get, path)
+      expect(response).to be_a(Net::HTTPNotFound)
+      expect(response.body).to include("No Dice", "does not exist")
+    end
+  end
+end

--- a/spec/catchmail_spec.rb
+++ b/spec/catchmail_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "open3"
+require "spec_helper"
+
+RSpec.describe "catchmail command", type: :feature do
+  def catchmail(*arguments, message:)
+    Open3.capture3(
+      "bundle", "exec", "catchmail",
+      "--smtp-ip", LOCALHOST,
+      "--smtp-port", SMTP_PORT.to_s,
+      *arguments,
+      stdin_data: message,
+    )
+  end
+
+  it "submits standard input using header or command-line recipients" do
+    header_message = <<~MESSAGE
+      From: Web App <web-app@example.com>
+      To: header-recipient@example.com
+      Subject: Header recipients
+
+      Sent through the sendmail interface.
+    MESSAGE
+    _, stderr, status = catchmail("-f", "bounce@example.com", "-t", message: header_message)
+    expect(status).to be_success, stderr
+
+    argument_message = <<~MESSAGE
+      From: Web App <web-app@example.com>
+      Subject: Argument recipients
+
+      Sent to command-line recipients.
+    MESSAGE
+    _, stderr, status = catchmail(
+      "-f", "sender@example.com",
+      "first@example.com", "second@example.com",
+      message: argument_message,
+    )
+    expect(status).to be_success, stderr
+
+    expect(page).to have_selector("#messages tbody tr", count: 2)
+    expect(page).to have_selector(
+      "#messages tbody tr",
+      text: "<bounce@example.com> <header-recipient@example.com> Header recipients",
+    )
+    expect(page).to have_selector(
+      "#messages tbody tr",
+      text: "<sender@example.com> <first@example.com>, <second@example.com> Argument recipients",
+    )
+  end
+end

--- a/spec/clear_spec.rb
+++ b/spec/clear_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Clear", type: :feature do
 
     # .. should display three emails
     expect(page).to have_selector("#messages table tbody tr", text: "Plain mail", count: 3)
+    expect(page).to have_title("MailCatcher (3)")
+
+    page.find("#messages table tbody tr:first-of-type").click
+    expect(page).to have_selector("#message dd.subject", text: "Plain mail")
 
     # Clicking Clear but cancelling ..
     dismiss_confirm do
@@ -27,5 +31,7 @@ RSpec.describe "Clear", type: :feature do
 
     # .. should display no emails
     expect(page).not_to have_selector("#messages table tbody tr")
+    expect(page).to have_selector("#message dd.subject", text: "", exact_text: true)
+    expect(page).to have_title("MailCatcher (0)")
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,19 +1,56 @@
+# frozen_string_literal: true
+
+require "open3"
 require "spec_helper"
 
 RSpec.describe "mailcatcher command" do
-  context "--version" do
-    it "shows a version then exits" do
-      expect { system %(mailcatcher --version) }
-        .to output(a_string_including("MailCatcher v#{MailCatcher::VERSION}"))
-        .to_stdout_from_any_process
-    end
+  it "shows its version then exits successfully" do
+    stdout, stderr, status = Open3.capture3("bundle", "exec", "mailcatcher", "--version")
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include("MailCatcher v#{MailCatcher::VERSION}")
   end
 
-  context "--help" do
-    it "shows help then exits" do
-      expect { system %(mailcatcher --help) }
-        .to output(a_string_including("MailCatcher v#{MailCatcher::VERSION}") & a_string_including("--help") & a_string_including("Display this help information"))
-        .to_stdout_from_any_process
-    end
+  it "documents its command-line configuration then exits successfully" do
+    stdout, stderr, status = Open3.capture3("bundle", "exec", "mailcatcher", "--help")
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include("MailCatcher v#{MailCatcher::VERSION}")
+    expect(stdout).to include(
+      "--ip", "--smtp-ip", "--smtp-port", "--http-ip", "--http-port",
+      "--messages-limit", "--http-path", "--no-quit", "--foreground",
+      "--verbose", "--help", "--version",
+    )
+    expect(stdout).to include("--browse") if MailCatcher.browsable?
+  end
+
+  it "reports an occupied port and exits unsuccessfully" do
+    listener = TCPServer.new(LOCALHOST, 0)
+    occupied_port = listener.local_address.ip_port
+
+    stdout, stderr, status = Open3.capture3(
+      "bundle", "exec", "mailcatcher", "--foreground",
+      "--smtp-port", occupied_port.to_s,
+      "--http-port", HTTP_PORT.to_s,
+    )
+
+    expect(status).not_to be_success
+    expect(stderr).to be_empty
+    expect(stdout).to include(
+      "Something's using port #{occupied_port}",
+      "smtp://127.0.0.1:#{occupied_port}",
+      "http://127.0.0.1:#{HTTP_PORT}",
+    )
+  ensure
+    listener&.close
+  end
+end
+
+RSpec.describe "catchmail command" do
+  it "shows its sendmail-compatible options then exits successfully" do
+    stdout, stderr, status = Open3.capture3("bundle", "exec", "catchmail", "--help")
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include("Usage: catchmail", "--smtp-ip", "--smtp-port", "-f FROM", "-t")
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Configuration", type: :feature do
+  def deliver_with_subject(subject)
+    deliver <<~MESSAGE
+      From: Sender <sender@example.com>
+      To: Recipient <recipient@example.com>
+      Subject: #{subject}
+      Content-Type: text/plain
+
+      #{subject} body
+    MESSAGE
+  end
+
+  it "keeps only the configured number of most recent messages",
+    mailcatcher_options: %w[--messages-limit 2] do
+    deliver_with_subject("First")
+    deliver_with_subject("Second")
+    deliver_with_subject("Third")
+
+    expect(page).to have_selector("#messages tbody tr", count: 2)
+    expect(page).to have_selector("#messages tbody tr", text: "Third")
+    expect(page).to have_selector("#messages tbody tr", text: "Second")
+    expect(page).to have_no_selector("#messages tbody tr", text: "First")
+  end
+
+  it "serves the complete application below an HTTP path prefix",
+    mailcatcher_options: %w[--ip 127.0.0.1 --http-path mail],
+    http_path: "/mail/" do
+    redirect = http_request(:get, "/")
+    expect(redirect).to be_a(Net::HTTPRedirection)
+    expect(redirect["Location"]).to eq("/mail")
+
+    expect(page).to have_current_path("/mail/")
+    deliver_with_subject("Prefixed message")
+    expect(page).to have_selector("#messages tbody tr", text: "Prefixed message")
+
+    page.find("#messages tbody tr", text: "Prefixed message").click
+    within_frame do
+      expect(page.find("body")).to have_text("Prefixed message body")
+    end
+
+    response = http_request(:get, "/mail/messages")
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body).fetch(0).fetch("subject")).to eq("Prefixed message")
+  end
+
+  it "hides and rejects the quit action when quitting is disabled",
+    mailcatcher_options: %w[--no-quit] do
+    expect(page).to have_no_link("Quit")
+
+    response = http_request(:delete, "/")
+    expect(response).to be_a(Net::HTTPForbidden)
+    expect { Process.kill(0, @pid) }.not_to raise_error
+  end
+end

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe MailCatcher, type: :feature do
     end
   end
 
+  it "catches multiple messages sent over one SMTP connection" do
+    Net::SMTP.start(LOCALHOST, SMTP_PORT) do |smtp|
+      smtp.send_message read_example("plainmail"), DEFAULT_FROM, DEFAULT_TO
+      smtp.send_message read_example("htmlmail"), DEFAULT_FROM, DEFAULT_TO
+    end
+
+    expect(page).to have_selector("#messages table tbody tr", count: 2)
+    expect(page).to have_selector("#messages table tbody tr", text: "Plain mail")
+    expect(page).to have_selector("#messages table tbody tr", text: "Test HTML Mail")
+  end
+
   it "catches and displays an html message as html and source" do
     deliver_example("htmlmail")
 
@@ -214,7 +225,18 @@ RSpec.describe MailCatcher, type: :feature do
 
     # Do not reload, make sure that the message appears via websockets
 
-    skip
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Test mail")
+
+    message_row_element.click
+
+    expect(source_tab_element).to be_visible
+    expect(page).to have_no_selector("#message header .format.plain a")
+    expect(page).to have_no_selector("#message header .format.html a")
+
+    within_frame do
+      expect(body_element).to have_text("Content-Type: application/x-weird")
+      expect(body_element).to have_text("Weird stuff~")
+    end
   end
 
   it "catches and displays a message with multipart attachments" do
@@ -247,6 +269,12 @@ RSpec.describe MailCatcher, type: :feature do
     # Downloading via the browser is hard, so just grab from the URI directly
     expect(Net::HTTP.get(URI.join(Capybara.app_host, first_attachment_element[:href]))).to eql("Hello, I am an attachment!\r\n")
 
+    download_element = page.find("#message .views .download a")
+    expect(download_element[:href]).to match(%r{/messages/[^/]+\.eml\z})
+    downloaded_message = Net::HTTP.get(URI(download_element[:href]))
+    expect(downloaded_message).to include("Subject: Test Attachment Mail")
+    expect(downloaded_message).to include("Content-Type: multipart/mixed")
+
     source_tab_element.click
 
     within_frame do
@@ -263,7 +291,15 @@ RSpec.describe MailCatcher, type: :feature do
 
     # Do not reload, make sure that the message appears via websockets
 
-    skip
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Whatever")
+
+    message_row_element.click
+    plain_tab_element.click
+
+    within_frame do
+      lines = body_element.text.lines.map(&:strip)
+      expect(lines).to include(".", "...", "Done.")
+    end
   end
 
   it "doesn't choke on messages containing quoted printables" do
@@ -271,6 +307,63 @@ RSpec.describe MailCatcher, type: :feature do
 
     # Do not reload, make sure that the message appears via websockets
 
-    skip
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Test quoted-printable HTML mail")
+
+    message_row_element.click
+    html_tab_element.click
+
+    within_frame do
+      expect(body_element).to have_text("Thank you for allowing Grand Rounds to provide a test case that may demonstrate a limitation in MailCatcher.")
+      link = page.find_link("here")
+      expect(link[:href]).to eq("http://localhost:9876/big/long/d50243b933ddd425")
+      expect(link[:target]).to eq("_blank")
+    end
+  end
+
+  it "renders XHTML messages as HTML" do
+    deliver_example("xhtmlmail")
+
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Test XHTML Mail")
+
+    message_row_element.click
+
+    expect(html_tab_element).to be_visible
+    expect(page).to have_no_selector("#message header .format.plain a")
+
+    within_frame do
+      expect(body_element).to have_text("Yo, you slimey scoundrel.")
+      expect(body_element).to have_no_text("<em>")
+    end
+  end
+
+  it "escapes and links URLs in plain text messages" do
+    deliver_example("plainlinkmail")
+
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Plain mail")
+
+    message_row_element.click
+    plain_tab_element.click
+
+    within_frame do
+      expect(body_element).to have_text('You "should" <really> visit:')
+      link = page.find_link("https://mailcatcher.me")
+      expect(link[:href]).to eq("https://mailcatcher.me/")
+      expect(link[:target]).to eq("_blank")
+    end
+  end
+
+  it "displays embedded images referenced by content ID" do
+    deliver_example("inlinemail")
+
+    expect(page).to have_selector("#messages table tbody tr:first-of-type", text: "Inline image")
+
+    message_row_element.click
+    html_tab_element.click
+
+    within_frame do
+      image = page.find("img[alt='A tiny image']")
+      expect(image[:src]).to match(%r{/messages/[^/]+/parts/inline-image@example\.com\z})
+      wait.until { image.evaluate_script("this.complete && this.naturalWidth === 1") }
+    end
   end
 end

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Inbox", type: :feature do
+  def deliver_message(subject, body: "Message body", content_type: "text/plain", **options)
+    deliver <<~MESSAGE, options
+      From: A User <user@example.com>
+      To: A Recipient <recipient@example.com>
+      Subject: #{subject}
+      Content-Type: #{content_type}
+
+      #{body}
+    MESSAGE
+  end
+
+  def message_rows
+    "#messages table tbody tr"
+  end
+
+  it "searches across message details without regard to case" do
+    deliver_message("Build finished", from: "buildbot@example.com")
+    deliver_message("Weekly Report", from: "reports@example.com")
+    deliver_message("Lunch plans", from: "friend@example.com")
+
+    expect(page).to have_selector(message_rows, count: 3)
+    expect(page).to have_title("MailCatcher (3)")
+
+    page.find("input[name=search]").set("REPORTS weekly")
+
+    expect(page).to have_selector(message_rows, count: 1, visible: true, text: "Weekly Report")
+    expect(page).to have_selector(message_rows, count: 3, visible: :all)
+
+    page.find("input[name=search]").set("")
+
+    expect(page).to have_selector(message_rows, count: 3, visible: true)
+  end
+
+  it "navigates messages and formats with the keyboard and deletes the selected message" do
+    deliver_message("First message")
+    deliver_message("Second message", body: "<p>Second body</p>", content_type: "text/html")
+    deliver_message("Third message")
+
+    expect(page).to have_selector(message_rows, count: 3)
+
+    body = page.find("body")
+    body.send_keys(:down)
+    expect(page).to have_selector("#{message_rows}.selected", text: "Third message")
+
+    body.send_keys(:down)
+    expect(page).to have_selector("#{message_rows}.selected", text: "Second message")
+    expect(page).to have_selector("#message dd.subject", text: "Second message")
+
+    body.send_keys(:right)
+    expect(page).to have_selector("#message li.format.source.selected")
+    within_frame do
+      expect(page.find("body")).to have_text("Content-Type: text/html")
+    end
+
+    body.send_keys(:left)
+    expect(page).to have_selector("#message li.format.html.selected")
+    within_frame do
+      expect(page.find("body")).to have_text("Second body")
+    end
+
+    body.send_keys(:delete)
+
+    expect(page).to have_no_selector(message_rows, text: "Second message")
+    expect(page).to have_selector(message_rows, count: 2)
+    expect(page).to have_selector("#{message_rows}.selected", text: "First message")
+    expect(page).to have_title("MailCatcher (2)")
+  end
+
+  it "remembers the message list height after a reload" do
+    initial_height = page.find("#messages").rect.height
+    resizer = page.find("#resizer")
+
+    page.driver.browser.action
+      .move_to(resizer.native)
+      .click_and_hold
+      .move_by(0, 80)
+      .release
+      .perform
+
+    resized_height = page.find("#messages").rect.height
+    expect(resized_height).to be > initial_height + 50
+
+    refresh
+    wait.until { page.evaluate_script("MailCatcher.websocket.readyState") == 1 rescue false }
+
+    expect(page.find("#messages").rect.height).to be_within(2).of(resized_height)
+  end
+
+  it "polls for new messages when WebSockets are unavailable", websocket: false do
+    deliver_message("Delivered by polling")
+
+    expect(page).to have_selector(message_rows, text: "Delivered by polling")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "selenium/webdriver"
 
 require "net/smtp"
 require "socket"
+require "timeout"
 
 require "mail_catcher"
 
@@ -68,10 +69,38 @@ RSpec.configure do |config|
     deliver(read_example(name), options)
   end
 
+  def http_request(method, path)
+    uri = URI.join("#{Capybara.app_host}/", path.sub(%r{\A/}, ""))
+    request_class = Net::HTTP.const_get(method.to_s.capitalize)
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      http.request(request_class.new(uri.request_uri))
+    end
+  end
+
+  def wait_for_server(pid)
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop do
+        smtp_ready = Socket.tcp(LOCALHOST, SMTP_PORT, connect_timeout: 1) { true } rescue false
+        http_ready = Socket.tcp(LOCALHOST, HTTP_PORT, connect_timeout: 1) { true } rescue false
+        break if smtp_ready && http_ready
+
+        if Process.waitpid(pid, Process::WNOHANG)
+          raise "MailCatcher exited before its servers were ready"
+        end
+
+        sleep 0.05
+      end
+    end
+  end
+
   # Teach RSpec to gather console errors from chrome when there are failures
   config.after(:each, type: :feature) do |example|
     # Did the example fail?
     next unless example.exception # "failed"
+
+    # API-only feature specs don't launch a browser.
+    next if example.metadata[:browser] == false
 
     # Do we have a browser?
     next unless page.driver.browser
@@ -96,33 +125,54 @@ RSpec.configure do |config|
   end
 
   def wait
-    Selenium::WebDriver::Wait.new
+    Selenium::WebDriver::Wait.new(timeout: Capybara.default_max_wait_time)
   end
 
-  config.before :each, type: :feature do
+  config.before :each, type: :feature do |example|
     # Start MailCatcher
-    @pid = spawn "bundle", "exec", "mailcatcher", "--foreground", "--smtp-port", SMTP_PORT.to_s, "--http-port", HTTP_PORT.to_s
+    command = [
+      "bundle", "exec", "mailcatcher", "--foreground",
+      "--smtp-port", SMTP_PORT.to_s,
+      "--http-port", HTTP_PORT.to_s,
+      *Array(example.metadata[:mailcatcher_options]),
+    ]
+    @pid = spawn(*command)
 
     # Wait for it to boot
-    begin
-      Socket.tcp(LOCALHOST, SMTP_PORT, connect_timeout: 1) { |s| s.close }
-      Socket.tcp(LOCALHOST, HTTP_PORT, connect_timeout: 1) { |s| s.close }
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      retry
+    wait_for_server(@pid)
+
+    next if example.metadata[:browser] == false
+
+    if example.metadata[:websocket] == false
+      result = page.driver.browser.execute_cdp(
+        "Page.addScriptToEvaluateOnNewDocument",
+        source: "window.WebSocket = undefined;",
+      )
+      @browser_setup_script = result["identifier"]
     end
 
     # Open the web interface
-    visit "/"
+    visit example.metadata.fetch(:http_path, "/")
 
     # Wait for the websocket to be available to avoid race conditions
-    wait.until { page.evaluate_script("MailCatcher.websocket.readyState") == 1 rescue false }
+    unless example.metadata[:websocket] == false
+      wait.until { page.evaluate_script("MailCatcher.websocket.readyState") == 1 rescue false }
+    end
   end
 
-  config.after :each, type: :feature do
+  config.append_after :each, type: :feature do
+    if @browser_setup_script
+      page.driver.browser.execute_cdp(
+        "Page.removeScriptToEvaluateOnNewDocument",
+        identifier: @browser_setup_script,
+      )
+      @browser_setup_script = nil
+    end
+
     # Quit MailCatcher
     Process.kill("TERM", @pid)
-    Process.wait
-  rescue Errno::ESRCH
+    Process.wait(@pid)
+  rescue Errno::ESRCH, Errno::ECHILD
     # It's already gone
   end
 end


### PR DESCRIPTION
## Why

MailCatcher's existing suite covers core delivery, clearing, and quitting, but leaves many browser workflows, the documented HTTP API, `catchmail`, and configuration behavior unprotected. Broader feature coverage will make larger implementation changes safer without coupling tests to internal units.

## What

Expand the suite from 13 to 30 external-behavior examples covering SMTP-to-browser delivery, WebSocket and polling updates, MIME rendering, attachments and downloads, inbox controls, the HTTP API, command-line workflows, and configured paths, limits, and quitting.

The new coverage also fixes two surfaced behaviors: `catchmail --help` now prints help and exits successfully, and message retention uses IDs to break timestamp ties so rapid deliveries reliably keep the newest messages.
