### PR TITLE
Support maintained Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ gem install mailcatcher
 
 ### Ruby
 
+MailCatcher requires Ruby 3.3 or newer.
+
 If you have trouble with the setup commands, make sure you have [Ruby installed](https://www.ruby-lang.org/en/documentation/installation/):
 
 ```

--- a/mailcatcher.gemspec
+++ b/mailcatcher.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.executables = ["mailcatcher", "catchmail"]
   s.extra_rdoc_files = ["README.md", "LICENSE"]
 
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "eventmachine", "~> 1.0"
   s.add_dependency "faye-websocket", "~> 0.11.1"
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "coffee-script"
   s.add_development_dependency "compass", "~> 1.0.3"
+  s.add_development_dependency "ostruct"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
## Why

Ruby 3.1 and 3.2 are end-of-life, but MailCatcher still declares and tests support for them. Ruby 4.0 is maintained but is missing from CI, and its standard-library changes expose an undeclared asset-build dependency.

## What

- Require Ruby 3.3 or newer and document the new minimum.
- Test Ruby 3.3, 3.4, and 4.0 on Linux and macOS.
- Declare `ostruct` explicitly so asset compilation works on Ruby 4.0.