### PR TITLE
Automate versioned releases to package registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,229 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+
+    - name: Validate release tag
+      id: release
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version="$(ruby -Ilib -rmail_catcher/version -e 'print MailCatcher::VERSION')"
+        if [[ "$GITHUB_REF_NAME" != "v$version" ]]; then
+          echo "Tag $GITHUB_REF_NAME does not match MailCatcher version $version" >&2
+          exit 1
+        fi
+
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+          echo "Tag $GITHUB_REF_NAME is not on the main branch" >&2
+          exit 1
+        fi
+
+        prerelease="$(ruby -rrubygems -e 'print Gem::Version.new(ARGV.fetch(0)).prerelease?' "$version")"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+
+    - name: Run tests
+      run: bundle exec rake test
+      timeout-minutes: 5
+
+    - name: Package candidate gem
+      run: bundle exec rake package
+
+    - name: Test candidate container
+      shell: bash
+      env:
+        TEST_IMAGE: mailcatcher-release-test:${{ github.run_id }}
+        VERSION: ${{ steps.release.outputs.version }}
+      run: |
+        set -euo pipefail
+        docker build \
+          --build-arg "VERSION=$VERSION" \
+          --secret "id=mailcatcher-gem,src=pkg/mailcatcher-$VERSION.gem" \
+          --tag "$TEST_IMAGE" \
+          .
+        MAILCATCHER_DOCKER_IMAGE="$TEST_IMAGE" ruby spec/docker_integration_test.rb
+
+  publish-gem:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+
+    - name: Check for an existing RubyGems release
+      id: rubygems
+      shell: bash
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        set -euo pipefail
+
+        gem_url="https://rubygems.org/downloads/mailcatcher-$VERSION.gem"
+        status="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$gem_url")"
+        case "$status" in
+          200)
+            mkdir -p pkg
+            curl --fail --silent --show-error --location \
+              --output "pkg/mailcatcher-$VERSION.gem" \
+              "$gem_url"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            ;;
+          404)
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "RubyGems.org returned HTTP $status for $gem_url" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Publish gem to RubyGems.org
+      if: steps.rubygems.outputs.published == 'false'
+      uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1
+
+    - name: Save gem for the GitHub release
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: gem
+        path: pkg/mailcatcher-${{ needs.validate.outputs.version }}.gem
+        if-no-files-found: error
+        retention-days: 1
+
+  publish-containers:
+    needs: [validate, publish-gem]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        scope: sj26/mailcatcher@pull,push
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+    - name: Set image metadata
+      id: metadata
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+      with:
+        images: |
+          sj26/mailcatcher
+          ghcr.io/${{ github.repository }}
+        tags: |
+          type=raw,value=${{ github.ref_name }}
+          type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+        labels: |
+          org.opencontainers.image.description=MailCatcher runs an SMTP server and displays caught email in a web interface.
+          org.opencontainers.image.licenses=MIT
+
+    - name: Build and publish container images
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: VERSION=${{ needs.validate.outputs.version }}
+        tags: ${{ steps.metadata.outputs.tags }}
+        labels: ${{ steps.metadata.outputs.labels }}
+
+  github-release:
+    needs: [validate, publish-gem, publish-containers]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+    - name: Download gem
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: gem
+        path: pkg
+
+    - name: Create GitHub release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        VERSION: ${{ needs.validate.outputs.version }}
+        PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+      run: |
+        set -euo pipefail
+
+        options=(
+          --verify-tag
+          --title "$GITHUB_REF_NAME"
+          --generate-notes
+        )
+        if [[ "$PRERELEASE" == "true" ]]; then
+          options+=(--prerelease)
+        fi
+
+        gh release create "$GITHUB_REF_NAME" \
+          "pkg/mailcatcher-$VERSION.gem" \
+          "${options[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM ruby:3.4-alpine
 MAINTAINER Samuel Cochran <sj26@sj26.com>
 
@@ -7,9 +9,14 @@ ARG VERSION=0.10.0
 
 # sqlite3 aarch64 is broken on alpine, so use ruby:
 # https://github.com/sparklemotion/sqlite3-ruby/issues/372
-RUN apk add --no-cache build-base libstdc++ sqlite-libs sqlite-dev && \
+RUN --mount=type=secret,id=mailcatcher-gem,target=/tmp/mailcatcher.gem \
+    apk add --no-cache build-base libstdc++ sqlite-libs sqlite-dev && \
     ( [ "$(uname -m)" != "aarch64" ] || gem install sqlite3 --version="~> 1.3" --platform=ruby ) && \
-    gem install mailcatcher -v "$VERSION" && \
+    if [ -f /tmp/mailcatcher.gem ]; then \
+      gem install /tmp/mailcatcher.gem; \
+    else \
+      gem install mailcatcher -v "$VERSION"; \
+    fi && \
     apk del --rdepends --purge build-base sqlite-dev
 
 EXPOSE 1025 1080

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,145 @@
+# Releasing MailCatcher
+
+Pushing a version tag publishes the gem to RubyGems.org, multi-platform
+container images to Docker Hub and GitHub Container Registry, and a GitHub
+release containing the gem. Alpha and beta versions become prereleases and do
+not update the `latest` container tag.
+
+## One-time publishing setup
+
+Configure these controls before creating the first release tag.
+
+### 1. Protect `main`
+
+1. In **Settings → Rules → Rulesets**, create a branch ruleset named
+   `protect-main`.
+2. Set **Enforcement status** to **Active** and target the default branch.
+3. Enable:
+   - restrict deletions
+   - require a pull request before merging
+   - dismiss stale approvals and require approval of the most recent push when
+     there is more than one maintainer
+   - require conversation resolution before merging
+   - require status checks to pass and require branches to be up to date
+   - block force pushes
+4. Require one approval when another maintainer is available. A repository with
+   only one maintainer must leave this at zero rather than create a rule nobody
+   can satisfy.
+5. Add the CI checks after they have run at least once:
+   - `docker`
+   - `test (ubuntu-latest, 3.3)`
+   - `test (ubuntu-latest, 3.4)`
+   - `test (ubuntu-latest, 4.0)`
+   - `test (macos-latest, 3.3)`
+   - `test (macos-latest, 3.4)`
+   - `test (macos-latest, 4.0)`
+
+Remove required checks that CI no longer emits. In particular, do not require
+the old Ruby 3.1 or 3.2 matrix checks.
+
+Do not add a normal bypass. Use an emergency administrator bypass only if the
+repository needs a documented break-glass path.
+
+### 2. Restrict release tags
+
+1. In **Settings → Rules → Rulesets**, create a tag ruleset named
+   `protect-release-tags`.
+2. Set **Enforcement status** to **Active** and target tags matching `v*`.
+3. Enable restrictions on tag creation, updates, and deletion, and block force
+   pushes.
+4. Add only the repository owner or designated release maintainers to the
+   bypass list with **Always allow**. Restricting creation means those are the
+   only actors who can create a release tag.
+
+Always create release tags from the protected `main` branch. The workflow also
+rejects a tag whose commit is not reachable from `origin/main`.
+
+### 3. Create the release environment
+
+1. In **Settings → Environments**, create an environment named `release`.
+2. Under **Deployment branches and tags**, choose **Selected branches and
+   tags**, add the tag pattern `v*`, and do not add a branch pattern.
+3. When another maintainer is available, add that person as a required reviewer
+   and enable **Prevent self-review**. Disable administrator bypass if the team
+   has a separate reviewer. A solo-maintainer repository must rely on the tag
+   ruleset instead of an impossible self-approval rule.
+4. Leave the environment secrets empty until the Docker publisher is ready.
+
+The tag rule controls who can start a release; the environment controls when
+publishing credentials and RubyGems OIDC are available. Both are required.
+
+### 4. Configure RubyGems trusted publishing
+
+On RubyGems.org, [add a trusted publisher](https://guides.rubygems.org/trusted-publishing/)
+to the `mailcatcher` gem with these exact values:
+
+- repository owner: `sj26`
+- repository name: `mailcatcher`
+- workflow filename: `release.yml`
+- environment: `release`
+
+No RubyGems API key is stored in GitHub.
+
+### 5. Configure the Docker Hub publisher
+
+1. Create a dedicated Docker ID used only to publish MailCatcher. Verify its
+   email address, enable two-factor authentication, and do not give it access
+   to any other Docker Hub repositories.
+2. While signed in as `sj26`, open the public `sj26/mailcatcher` repository's
+   **Collaborators** tab and add the publisher Docker ID. Docker Hub grants a
+   collaborator push and pull access to this repository, but not repository
+   administration or deletion access.
+3. While signed in as the publisher, [create a personal access token](https://docs.docker.com/security/access-tokens/)
+   named `mailcatcher-github-releases` with read and write permissions, but not
+   delete permission. Set an expiration date and arrange to rotate it before it
+   expires.
+4. On the GitHub `release` environment, add:
+   - environment variable `DOCKERHUB_USERNAME`: the publisher Docker ID
+   - environment secret `DOCKERHUB_TOKEN`: the publisher's token
+
+Do not use a repository secret. Restricting the token to the environment keeps
+workflows on ordinary branches from requesting it.
+
+### 6. Configure GitHub Container Registry
+
+No credential is required: the workflow uses its short-lived `GITHUB_TOKEN`.
+After the first release creates `ghcr.io/sj26/mailcatcher`, open the package's
+settings and make it public.
+
+RubyGems uses OIDC trusted publishing and GitHub Container Registry uses the
+workflow's short-lived `GITHUB_TOKEN`. Docker Hub only supports OIDC for
+organizations. A personal token is still account-wide for the dedicated
+publisher's own account, but within the `sj26` namespace that account has
+server-side access only to `sj26/mailcatcher`. A compromised publisher could
+create content in its own namespace but could not modify other `sj26`
+repositories. The workflow additionally limits Buildx's use of that credential
+to pull and push requests for `sj26/mailcatcher`; that client-side scope is
+defense in depth, not a substitute for the dedicated account.
+
+## Publish a release
+
+1. Change `MailCatcher::VERSION` in `lib/mail_catcher/version.rb` on a branch,
+   open a pull request, and merge it after every required check passes.
+2. Update local `main`, verify the version, and tag that commit with the exact
+   version prefixed by `v`:
+
+   ```console
+   git switch main
+   git pull --ff-only origin main
+   ruby -Ilib -rmail_catcher/version -e 'puts MailCatcher::VERSION'
+   git tag v0.11.0
+   git push origin v0.11.0
+   ```
+
+3. Approve the `release` environment deployment when GitHub prompts for it.
+4. Confirm that the workflow completed and that the same version exists on
+   RubyGems.org, Docker Hub, GHCR, and GitHub Releases. For stable releases,
+   confirm both container registries also moved `latest` to the new version.
+
+If a registry is temporarily unavailable, rerun the failed workflow. A rerun
+reuses the immutable gem already published on RubyGems.org and retries the
+remaining container and GitHub release steps.
+
+The release workflow rejects a tag that does not exactly match
+`MailCatcher::VERSION`. Ruby prerelease versions retain the existing dot form,
+for example `v0.11.0.beta1`.

--- a/Rakefile
+++ b/Rakefile
@@ -4,18 +4,21 @@ require "mail_catcher/version"
 
 desc "Package as Gem"
 task "package" do
+  require "fileutils"
   require "rubygems/package"
   require "rubygems/specification"
 
   spec_file = File.expand_path("../mailcatcher.gemspec", __FILE__)
   spec = Gem::Specification.load(spec_file)
+  package_dir = File.expand_path("pkg", __dir__)
 
-  Gem::Package.build spec
+  FileUtils.mkdir_p package_dir
+  Gem::Package.build spec, false, false, File.join(package_dir, spec.file_name)
 end
 
 desc "Release Gem to RubyGems"
 task "release" => ["package"] do
-  %x[gem push mailcatcher-#{MailCatcher::VERSION}.gem]
+  sh "gem", "push", File.expand_path("pkg/mailcatcher-#{MailCatcher::VERSION}.gem", __dir__)
 end
 
 desc "Build and push Docker images (optional: VERSION=#{MailCatcher::VERSION})"

--- a/spec/docker_integration_test.rb
+++ b/spec/docker_integration_test.rb
@@ -9,7 +9,7 @@ require "securerandom"
 require "socket"
 
 ROOT = File.expand_path("..", __dir__)
-IMAGE = "mailcatcher-integration-test:#{Process.pid}"
+IMAGE = ENV.fetch("MAILCATCHER_DOCKER_IMAGE", "mailcatcher-integration-test:#{Process.pid}")
 SUBJECT = "Docker integration #{SecureRandom.hex(6)}"
 PLAIN_TEXT = "MailCatcher received this message over SMTP."
 HTML_TEXT = "MailCatcher rendered this HTML message."
@@ -80,8 +80,10 @@ end
 container = nil
 
 begin
-  puts "Building #{IMAGE}"
-  system("docker", "build", "--tag", IMAGE, ROOT) || raise("Docker image build failed")
+  unless ENV.key?("MAILCATCHER_DOCKER_IMAGE")
+    puts "Building #{IMAGE}"
+    system("docker", "build", "--tag", IMAGE, ROOT) || raise("Docker image build failed")
+  end
 
   container = capture!(
     "docker", "run", "--detach",


### PR DESCRIPTION
## Why

MailCatcher releases currently require separate manual pushes to RubyGems, Docker Hub, and GitHub. That makes it easy for release artifacts and prerelease metadata to drift between distribution channels.

## What

Adds a protected-tag release workflow that validates the tag against `MailCatcher::VERSION` and `main`, tests the packaged gem in the container, publishes through RubyGems trusted publishing, pushes matching amd64/arm64 images to Docker Hub and GHCR, and creates the GitHub release with the gem attached. Stable versions update `latest`; prereleases do not.

The release guide documents the required branch, tag, and environment controls plus a dedicated Docker Hub collaborator account so the personal `sj26` namespace does not need to become an organization.
