### PR TITLE
Bump v0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,8 @@ jobs:
         set -euo pipefail
 
         gem_url="https://rubygems.org/downloads/mailcatcher-$VERSION.gem"
-        status="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$gem_url")"
+        version_url="https://rubygems.org/api/v2/rubygems/mailcatcher/versions/$VERSION.json"
+        status="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$version_url")"
         case "$status" in
           200)
             mkdir -p pkg
@@ -115,7 +116,7 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
             ;;
           *)
-            echo "RubyGems.org returned HTTP $status for $gem_url" >&2
+            echo "RubyGems.org returned HTTP $status for $version_url" >&2
             exit 1
             ;;
         esac

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Samuel Cochran <sj26@sj26.com>
 
 # Use --build-arg VERSION=... to override
 # or `rake docker VERSION=...`
-ARG VERSION=0.10.0
+ARG VERSION=0.11.0
 
 # sqlite3 aarch64 is broken on alpine, so use ruby:
 # https://github.com/sparklemotion/sqlite3-ruby/issues/372

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Samuel Cochran <sj26@sj26.com>
 
 # Use --build-arg VERSION=... to override
 # or `rake docker VERSION=...`
-ARG VERSION=0.11.0
+ARG VERSION=0.10.0
 
 # sqlite3 aarch64 is broken on alpine, so use ruby:
 # https://github.com/sparklemotion/sqlite3-ruby/issues/372

--- a/lib/mail_catcher/version.rb
+++ b/lib/mail_catcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailCatcher
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end


### PR DESCRIPTION
## Why

MailCatcher is ready for its first stable release since v0.10.0, including maintained Ruby support, dependency updates, broader feature coverage, and the simplified frontend.

## What

Bumps the gem version to `0.11.0`. The container's default remains on the published `0.10.0` gem so pre-release CI can build; the release workflow supplies `VERSION=0.11.0` after RubyGems publishing.

This also corrects the new release workflow to query RubyGems' exact-version API, because the downloads CDN returns 403 rather than 404 for an unpublished gem and would otherwise block this first automated release.
